### PR TITLE
feat: registro atómico de paciente + historia (medicina y nutrición)

### DIFF
--- a/backend/src/__tests__/medicalPatientRegistration.test.js
+++ b/backend/src/__tests__/medicalPatientRegistration.test.js
@@ -1,0 +1,103 @@
+/**
+ * @file Tests de integración para el registro atómico de paciente de medicina.
+ *
+ * POST /medicina/pacientes crea paciente + 1ª historia médica en una sola
+ * transacción. Verifica el happy path, atomicidad ante input inválido, y guards
+ * de sesión/área.
+ */
+
+import request from 'supertest'
+import app from '#app'
+import { prisma } from '#config/prisma.js'
+import { uuidToBuffer } from '#lib/uuid.js'
+import { authenticatedCoordinador } from './helpers/agents.js'
+import { createCleanupTracker } from './helpers/cleanup.js'
+
+const api = request(app)
+const tracker = createCleanupTracker()
+
+let agent
+let nutricionAgent
+
+beforeAll(async () => {
+  const auth = await authenticatedCoordinador({ area: 'MEDICINA', tracker })
+  agent = auth.agent
+
+  const nut = await authenticatedCoordinador({ area: 'NUTRICION', tracker })
+  nutricionAgent = nut.agent
+})
+
+afterAll(() => tracker.cleanup())
+
+// ── Factories ──────────────────────────────────────────────────────────
+
+const buildPatient = (overrides = {}) => ({
+  nombre: 'Registro',
+  apellidos: 'Médico',
+  fecha_nacimiento: '2000-01-01',
+  genero: 'Femenino',
+  telefono: '5598765432',
+  ...overrides,
+})
+
+const buildBody = (overrides = {}) => ({
+  patient: buildPatient(),
+  historia: {
+    motivo_consulta: 'Dolor abdominal',
+    tipo_sangre: 'O+',
+    antecedentes_familiares: { padre: 'Diabetes', madre: 'HAS' },
+  },
+  ...overrides,
+})
+
+const trackResult = ({ patient, historia }) => {
+  tracker.track('historias_medicas', uuidToBuffer(historia.id))
+  tracker.track('pacientes', uuidToBuffer(patient.id))
+}
+
+// ── POST /medicina/pacientes ───────────────────────────────────────────
+
+describe('POST /medicina/pacientes', () => {
+  test('401 — sin sesión devuelve 401', async () => {
+    const res = await api.post('/medicina/pacientes').send(buildBody())
+    expect(res.status).toBe(401)
+  })
+
+  test('403 — usuario de otra área no puede registrar', async () => {
+    const res = await nutricionAgent.post('/medicina/pacientes').send(buildBody())
+    expect(res.status).toBe(403)
+  })
+
+  test('201 — crea paciente + historia médica atómicamente', async () => {
+    const res = await agent.post('/medicina/pacientes').send(buildBody())
+    expect(res.status).toBe(201)
+
+    const { patient, historia } = res.body
+    expect(patient.id).toBeDefined()
+    expect(patient.nombre).toBe('Registro')
+    expect(historia.id).toBeDefined()
+    expect(historia.paciente_id).toBe(patient.id)
+    expect(historia.antecedentes_familiares.padre).toBe('Diabetes')
+
+    trackResult(res.body)
+
+    const fromDb = await prisma.historias_medicas.findFirst({
+      where: { paciente_id: uuidToBuffer(patient.id) },
+    })
+    expect(fromDb).not.toBeNull()
+  })
+
+  test('422 — input inválido no crea ningún paciente (atomicidad)', async () => {
+    const nombre = `ZZ_${Date.now()}`
+    const res = await agent.post('/medicina/pacientes').send(
+      buildBody({
+        patient: buildPatient({ nombre, telefono: '123' }), // teléfono inválido
+      })
+    )
+    expect(res.status).toBe(422)
+    expect(res.body.error).toBe('ValidationError')
+
+    const found = await prisma.pacientes.findFirst({ where: { nombre } })
+    expect(found).toBeNull()
+  })
+})

--- a/backend/src/__tests__/medicalPatientRegistration.test.js
+++ b/backend/src/__tests__/medicalPatientRegistration.test.js
@@ -27,7 +27,9 @@ beforeAll(async () => {
   nutricionAgent = nut.agent
 })
 
-afterAll(() => tracker.cleanup())
+afterAll(async () => {
+  await tracker.cleanup()
+})
 
 // ── Factories ──────────────────────────────────────────────────────────
 

--- a/backend/src/__tests__/nutritionPatientRegistration.test.js
+++ b/backend/src/__tests__/nutritionPatientRegistration.test.js
@@ -27,7 +27,9 @@ beforeAll(async () => {
   medicinaAgent = med.agent
 })
 
-afterAll(() => tracker.cleanup())
+afterAll(async () => {
+  await tracker.cleanup()
+})
 
 // ── Factories ──────────────────────────────────────────────────────────
 

--- a/backend/src/__tests__/nutritionPatientRegistration.test.js
+++ b/backend/src/__tests__/nutritionPatientRegistration.test.js
@@ -1,0 +1,106 @@
+/**
+ * @file Tests de integración para el registro atómico de paciente de nutrición.
+ *
+ * POST /nutricion/pacientes crea paciente + 1ª historia nutricional en una sola
+ * transacción. Verifica el happy path, atomicidad ante input inválido, y guards
+ * de sesión/área.
+ */
+
+import request from 'supertest'
+import app from '#app'
+import { prisma } from '#config/prisma.js'
+import { uuidToBuffer } from '#lib/uuid.js'
+import { authenticatedCoordinador } from './helpers/agents.js'
+import { createCleanupTracker } from './helpers/cleanup.js'
+
+const api = request(app)
+const tracker = createCleanupTracker()
+
+let agent
+let medicinaAgent
+
+beforeAll(async () => {
+  const auth = await authenticatedCoordinador({ area: 'NUTRICION', tracker })
+  agent = auth.agent
+
+  const med = await authenticatedCoordinador({ area: 'MEDICINA', tracker })
+  medicinaAgent = med.agent
+})
+
+afterAll(() => tracker.cleanup())
+
+// ── Factories ──────────────────────────────────────────────────────────
+
+const buildPatient = (overrides = {}) => ({
+  nombre: 'Registro',
+  apellidos: 'Atómico',
+  fecha_nacimiento: '2000-01-01',
+  genero: 'Masculino',
+  telefono: '5512345678',
+  ...overrides,
+})
+
+const buildBody = (overrides = {}) => ({
+  patient: buildPatient(),
+  historia: {
+    motivo_consulta: 'Control de peso',
+    historias_medicas_nutricion: [{ enfermedad: 'DM2', evol: 5, farmacos: 'Metformina' }],
+    adicciones: { adicto_tabaco: 'si', tabaco_frecuencia: 'Diario', num_cigarros_d: 10 },
+  },
+  ...overrides,
+})
+
+const trackResult = ({ patient, historia }) => {
+  tracker.track('historias_pacientes_nutricion', uuidToBuffer(historia.id))
+  tracker.track('pacientes', uuidToBuffer(patient.id))
+  if (historia.adicciones?.id) tracker.track('adicciones', historia.adicciones.id)
+}
+
+// ── POST /nutricion/pacientes ──────────────────────────────────────────
+
+describe('POST /nutricion/pacientes', () => {
+  test('401 — sin sesión devuelve 401', async () => {
+    const res = await api.post('/nutricion/pacientes').send(buildBody())
+    expect(res.status).toBe(401)
+  })
+
+  test('403 — usuario de otra área no puede registrar', async () => {
+    const res = await medicinaAgent.post('/nutricion/pacientes').send(buildBody())
+    expect(res.status).toBe(403)
+  })
+
+  test('201 — crea paciente + historia nutricional atómicamente', async () => {
+    const res = await agent.post('/nutricion/pacientes').send(buildBody())
+    expect(res.status).toBe(201)
+
+    const { patient, historia } = res.body
+    expect(patient.id).toBeDefined()
+    expect(patient.nombre).toBe('Registro')
+    expect(historia.id).toBeDefined()
+    expect(historia.paciente_id).toBe(patient.id)
+    expect(historia.historias_medicas_nutricion).toHaveLength(1)
+    expect(historia.adicciones.adicto_tabaco).toBe('si')
+
+    trackResult(res.body)
+
+    // La historia quedó realmente persistida y ligada al paciente.
+    const fromDb = await prisma.historias_pacientes_nutricion.findFirst({
+      where: { paciente_id: uuidToBuffer(patient.id) },
+    })
+    expect(fromDb).not.toBeNull()
+  })
+
+  test('422 — input inválido no crea ningún paciente (atomicidad)', async () => {
+    const nombre = `ZZ_${Date.now()}`
+    const res = await agent.post('/nutricion/pacientes').send(
+      buildBody({
+        patient: buildPatient({ nombre, genero: '' }), // género vacío → inválido
+      })
+    )
+    expect(res.status).toBe(422)
+    expect(res.body.error).toBe('ValidationError')
+
+    const found = await prisma.pacientes.findFirst({ where: { nombre } })
+    expect(found).toBeNull()
+  })
+})

--- a/backend/src/controllers/medicina/patientRegistration.js
+++ b/backend/src/controllers/medicina/patientRegistration.js
@@ -1,55 +1,11 @@
-import { prisma } from '#config/prisma.js'
-import { PatientModel } from '#models/PatientModel.js'
 import { MedicalHistoryModel } from '#models/medicina/MedicalHistory.js'
-import { AuditModel } from '#models/AuditModel.js'
+import { makePatientRegistrationController } from '#controllers/patientRegistration.js'
 import { validateMedicalRegistration } from '@cais/shared/schemas/medicina/patientRegistration'
-import { formatZodErrors } from '#lib/formatErrors.js'
-import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+import { ENTIDADES } from '@cais/shared/constants/users'
 
-export class MedicalPatientRegistrationController {
-  static async create(req, res) {
-    const result = validateMedicalRegistration(req.body)
-    if (result.error) {
-      return res.status(422).json({
-        error: 'ValidationError',
-        message: 'Datos de registro inválidos',
-        fields: formatZodErrors(result.error),
-      })
-    }
-
-    const { patient, historia } = result.data
-    const userId = req.session.userId
-
-    try {
-      const data = await prisma.$transaction(async (tx) => {
-        const p = await PatientModel.create(patient, userId, tx)
-        const h = await MedicalHistoryModel.create({ ...historia, paciente_id: p.id }, userId, tx)
-        await AuditModel.create(
-          {
-            usuario_id: userId,
-            accion: ACCIONES.CREAR,
-            entidad: ENTIDADES.PACIENTE,
-            objetivo_id: p.id,
-            paciente_id: p.id,
-          },
-          tx
-        )
-        await AuditModel.create(
-          {
-            usuario_id: userId,
-            accion: ACCIONES.CREAR,
-            entidad: ENTIDADES.HISTORIA_MEDICA,
-            objetivo_id: h.id,
-            paciente_id: p.id,
-          },
-          tx
-        )
-        return { patient: p, historia: h }
-      })
-      return res.status(201).json({ message: 'Paciente registrado', ...data })
-    } catch (err) {
-      console.error('Error al registrar paciente de medicina:', err)
-      return res.status(500).json({ error: 'Error al registrar al paciente' })
-    }
-  }
-}
+export const MedicalPatientRegistrationController = makePatientRegistrationController({
+  validate: validateMedicalRegistration,
+  createHistory: (data, userId, tx) => MedicalHistoryModel.create(data, userId, tx),
+  historiaEntidad: ENTIDADES.HISTORIA_MEDICA,
+  errorLabel: 'medicina',
+})

--- a/backend/src/controllers/medicina/patientRegistration.js
+++ b/backend/src/controllers/medicina/patientRegistration.js
@@ -1,0 +1,55 @@
+import { prisma } from '#config/prisma.js'
+import { PatientModel } from '#models/PatientModel.js'
+import { MedicalHistoryModel } from '#models/medicina/MedicalHistory.js'
+import { AuditModel } from '#models/AuditModel.js'
+import { validateMedicalRegistration } from '@cais/shared/schemas/medicina/patientRegistration'
+import { formatZodErrors } from '#lib/formatErrors.js'
+import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+
+export class MedicalPatientRegistrationController {
+  static async create(req, res) {
+    const result = validateMedicalRegistration(req.body)
+    if (result.error) {
+      return res.status(422).json({
+        error: 'ValidationError',
+        message: 'Datos de registro inválidos',
+        fields: formatZodErrors(result.error),
+      })
+    }
+
+    const { patient, historia } = result.data
+    const userId = req.session.userId
+
+    try {
+      const data = await prisma.$transaction(async (tx) => {
+        const p = await PatientModel.create(patient, userId, tx)
+        const h = await MedicalHistoryModel.create({ ...historia, paciente_id: p.id }, userId, tx)
+        await AuditModel.create(
+          {
+            usuario_id: userId,
+            accion: ACCIONES.CREAR,
+            entidad: ENTIDADES.PACIENTE,
+            objetivo_id: p.id,
+            paciente_id: p.id,
+          },
+          tx
+        )
+        await AuditModel.create(
+          {
+            usuario_id: userId,
+            accion: ACCIONES.CREAR,
+            entidad: ENTIDADES.HISTORIA_MEDICA,
+            objetivo_id: h.id,
+            paciente_id: p.id,
+          },
+          tx
+        )
+        return { patient: p, historia: h }
+      })
+      return res.status(201).json({ message: 'Paciente registrado', ...data })
+    } catch (err) {
+      console.error('Error al registrar paciente de medicina:', err)
+      return res.status(500).json({ error: 'Error al registrar al paciente' })
+    }
+  }
+}

--- a/backend/src/controllers/nutricion/patientRegistration.js
+++ b/backend/src/controllers/nutricion/patientRegistration.js
@@ -1,0 +1,55 @@
+import { prisma } from '#config/prisma.js'
+import { PatientModel } from '#models/PatientModel.js'
+import { NutritionHistoryModel } from '#models/nutricion/NutritionHistory.js'
+import { AuditModel } from '#models/AuditModel.js'
+import { validateNutritionRegistration } from '@cais/shared/schemas/nutricion/patientRegistration'
+import { formatZodErrors } from '#lib/formatErrors.js'
+import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+
+export class NutritionPatientRegistrationController {
+  static async create(req, res) {
+    const result = validateNutritionRegistration(req.body)
+    if (result.error) {
+      return res.status(422).json({
+        error: 'ValidationError',
+        message: 'Datos de registro inválidos',
+        fields: formatZodErrors(result.error),
+      })
+    }
+
+    const { patient, historia } = result.data
+    const userId = req.session.userId
+
+    try {
+      const data = await prisma.$transaction(async (tx) => {
+        const p = await PatientModel.create(patient, userId, tx)
+        const h = await NutritionHistoryModel.create({ ...historia, paciente_id: p.id }, tx)
+        await AuditModel.create(
+          {
+            usuario_id: userId,
+            accion: ACCIONES.CREAR,
+            entidad: ENTIDADES.PACIENTE,
+            objetivo_id: p.id,
+            paciente_id: p.id,
+          },
+          tx
+        )
+        await AuditModel.create(
+          {
+            usuario_id: userId,
+            accion: ACCIONES.CREAR,
+            entidad: ENTIDADES.HISTORIA_NUTRICION,
+            objetivo_id: h.id,
+            paciente_id: p.id,
+          },
+          tx
+        )
+        return { patient: p, historia: h }
+      })
+      return res.status(201).json({ message: 'Paciente registrado', ...data })
+    } catch (err) {
+      console.error('Error al registrar paciente de nutrición:', err)
+      return res.status(500).json({ error: 'Error al registrar al paciente' })
+    }
+  }
+}

--- a/backend/src/controllers/nutricion/patientRegistration.js
+++ b/backend/src/controllers/nutricion/patientRegistration.js
@@ -1,55 +1,11 @@
-import { prisma } from '#config/prisma.js'
-import { PatientModel } from '#models/PatientModel.js'
 import { NutritionHistoryModel } from '#models/nutricion/NutritionHistory.js'
-import { AuditModel } from '#models/AuditModel.js'
+import { makePatientRegistrationController } from '#controllers/patientRegistration.js'
 import { validateNutritionRegistration } from '@cais/shared/schemas/nutricion/patientRegistration'
-import { formatZodErrors } from '#lib/formatErrors.js'
-import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+import { ENTIDADES } from '@cais/shared/constants/users'
 
-export class NutritionPatientRegistrationController {
-  static async create(req, res) {
-    const result = validateNutritionRegistration(req.body)
-    if (result.error) {
-      return res.status(422).json({
-        error: 'ValidationError',
-        message: 'Datos de registro inválidos',
-        fields: formatZodErrors(result.error),
-      })
-    }
-
-    const { patient, historia } = result.data
-    const userId = req.session.userId
-
-    try {
-      const data = await prisma.$transaction(async (tx) => {
-        const p = await PatientModel.create(patient, userId, tx)
-        const h = await NutritionHistoryModel.create({ ...historia, paciente_id: p.id }, tx)
-        await AuditModel.create(
-          {
-            usuario_id: userId,
-            accion: ACCIONES.CREAR,
-            entidad: ENTIDADES.PACIENTE,
-            objetivo_id: p.id,
-            paciente_id: p.id,
-          },
-          tx
-        )
-        await AuditModel.create(
-          {
-            usuario_id: userId,
-            accion: ACCIONES.CREAR,
-            entidad: ENTIDADES.HISTORIA_NUTRICION,
-            objetivo_id: h.id,
-            paciente_id: p.id,
-          },
-          tx
-        )
-        return { patient: p, historia: h }
-      })
-      return res.status(201).json({ message: 'Paciente registrado', ...data })
-    } catch (err) {
-      console.error('Error al registrar paciente de nutrición:', err)
-      return res.status(500).json({ error: 'Error al registrar al paciente' })
-    }
-  }
-}
+export const NutritionPatientRegistrationController = makePatientRegistrationController({
+  validate: validateNutritionRegistration,
+  createHistory: (data, _userId, tx) => NutritionHistoryModel.create(data, tx),
+  historiaEntidad: ENTIDADES.HISTORIA_NUTRICION,
+  errorLabel: 'nutrición',
+})

--- a/backend/src/controllers/patientRegistration.js
+++ b/backend/src/controllers/patientRegistration.js
@@ -1,0 +1,71 @@
+import { prisma } from '#config/prisma.js'
+import { PatientModel } from '#models/PatientModel.js'
+import { AuditModel } from '#models/AuditModel.js'
+import { formatZodErrors } from '#lib/formatErrors.js'
+import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+
+/**
+ * Construye un controller de registro atómico (paciente + 1ª historia) por área.
+ * Medicina y nutrición solo difieren en el schema de validación, el modelo de
+ * historia y la entidad auditada, así que el flujo vive aquí una sola vez.
+ *
+ * @param {object} deps
+ * @param {(body: object) => object} deps.validate - validateXRegistration (safeParse)
+ * @param {(data: object, userId: string, tx: object) => Promise} deps.createHistory
+ * @param {string} deps.historiaEntidad - ENTIDADES.HISTORIA_*
+ * @param {string} deps.errorLabel - área para el log de error
+ */
+export function makePatientRegistrationController({
+  validate,
+  createHistory,
+  historiaEntidad,
+  errorLabel,
+}) {
+  return {
+    async create(req, res) {
+      const result = validate(req.body)
+      if (result.error) {
+        return res.status(422).json({
+          error: 'ValidationError',
+          message: 'Datos de registro inválidos',
+          fields: formatZodErrors(result.error),
+        })
+      }
+
+      const { patient, historia } = result.data
+      const userId = req.session.userId
+
+      try {
+        const data = await prisma.$transaction(async (tx) => {
+          const p = await PatientModel.create(patient, userId, tx)
+          const h = await createHistory({ ...historia, paciente_id: p.id }, userId, tx)
+          await AuditModel.create(
+            {
+              usuario_id: userId,
+              accion: ACCIONES.CREAR,
+              entidad: ENTIDADES.PACIENTE,
+              objetivo_id: p.id,
+              paciente_id: p.id,
+            },
+            tx
+          )
+          await AuditModel.create(
+            {
+              usuario_id: userId,
+              accion: ACCIONES.CREAR,
+              entidad: historiaEntidad,
+              objetivo_id: h.id,
+              paciente_id: p.id,
+            },
+            tx
+          )
+          return { patient: p, historia: h }
+        })
+        return res.status(201).json({ message: 'Paciente registrado', ...data })
+      } catch (err) {
+        console.error(`Error al registrar paciente de ${errorLabel}:`, err)
+        return res.status(500).json({ error: 'Error al registrar al paciente' })
+      }
+    },
+  }
+}

--- a/backend/src/routes/medicina/patientRegistration.js
+++ b/backend/src/routes/medicina/patientRegistration.js
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import { MedicalPatientRegistrationController } from '#controllers/medicina/patientRegistration.js'
+import { requireAuth } from '#middleware/auth.js'
+
+export const medicalPatientRegistrationRouter = Router()
+
+medicalPatientRegistrationRouter.use(requireAuth)
+
+medicalPatientRegistrationRouter.post('/', MedicalPatientRegistrationController.create)

--- a/backend/src/routes/medicine.js
+++ b/backend/src/routes/medicine.js
@@ -3,6 +3,7 @@ import { requireAuth, requireArea } from '#middleware/auth.js'
 import { emergencyRouter } from './medicina/emergencies.js'
 import { evolutionNotesRouter } from './medicina/evolutionNotes.js'
 import { medicalHistoryRouter } from './medicina/medicalHistory.js'
+import { medicalPatientRegistrationRouter } from './medicina/patientRegistration.js'
 import { AREAS } from '@cais/shared/constants/users'
 
 export const medicineRouter = Router()
@@ -10,6 +11,7 @@ export const medicineRouter = Router()
 medicineRouter.use(requireAuth)
 medicineRouter.use(requireArea(AREAS.MEDICINA))
 
+medicineRouter.use('/pacientes', medicalPatientRegistrationRouter)
 medicineRouter.use('/emergencias', emergencyRouter)
 medicineRouter.use('/notas-evolucion', evolutionNotesRouter)
 medicineRouter.use('/historias-medicas', medicalHistoryRouter)

--- a/backend/src/routes/nutricion/patientRegistration.js
+++ b/backend/src/routes/nutricion/patientRegistration.js
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import { NutritionPatientRegistrationController } from '#controllers/nutricion/patientRegistration.js'
+import { requireAuth } from '#middleware/auth.js'
+
+export const nutritionPatientRegistrationRouter = Router()
+
+nutritionPatientRegistrationRouter.use(requireAuth)
+
+nutritionPatientRegistrationRouter.post('/', NutritionPatientRegistrationController.create)

--- a/backend/src/routes/nutrition.js
+++ b/backend/src/routes/nutrition.js
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { requireAuth, requireArea } from '#middleware/auth.js'
 import { AREAS } from '@cais/shared/constants/users'
 import { nutritionHistoryRouter } from './nutricion/nutritionHistory.js'
+import { nutritionPatientRegistrationRouter } from './nutricion/patientRegistration.js'
 import { biochemicalEvalRouter } from './nutricion/biochemicalEval.js'
 import { nutritionalEvalRouter } from './nutricion/nutritionalEval.js'
 
@@ -10,6 +11,7 @@ export const nutritionRouter = Router()
 nutritionRouter.use(requireAuth)
 nutritionRouter.use(requireArea(AREAS.NUTRICION))
 
+nutritionRouter.use('/pacientes', nutritionPatientRegistrationRouter)
 nutritionRouter.use('/historias-nutricion', nutritionHistoryRouter)
 nutritionRouter.use('/evaluacion-bioquimica', biochemicalEvalRouter)
 nutritionRouter.use('/evaluacion-nutricional', nutritionalEvalRouter)

--- a/docs/plan-registro-atomico.md
+++ b/docs/plan-registro-atomico.md
@@ -1,0 +1,211 @@
+# Plan: registro atómico de paciente + historia (medicina y nutrición)
+
+> PR aparte. Diseñado siguiendo principios REST (resource-oriented, semántica HTTP
+> correcta, validación en capas) y los estándares de `backend/CLAUDE.md` y
+> `frontend/CLAUDE.md`.
+
+## Problema
+
+El registro de un paciente toca **dos recursos** (paciente + su primera historia)
+mediante **dos requests HTTP separados**, cada uno con su propia `$transaction`:
+
+```
+POST /pacientes                      → tx1: crea paciente   (commit)
+POST /nutricion/historias-nutricion  → tx2: crea historia   (commit)
+```
+
+El hook del frontend encadena ambas y, si la segunda falla, hace `deletePatient`
+desde el cliente como "rollback". No hay atomicidad entre los dos commits:
+
+- Si la creación de la historia falla **y** el `deletePatient` también (red caída,
+  500, browser cerrado), queda un **paciente huérfano** sin historia; solo se
+  loguea en consola.
+- Entre tx1 y tx2 el paciente existe en estado incompleto (lo puede leer otra
+  request).
+
+Es un hueco de correctitud de baja probabilidad (no un crash). **Aplica igual a
+medicina y nutrición** (hooks gemelos `useCreatePatientWithHistory` /
+`useCreatePatientWithNutritionHistory`).
+
+## Solución: una sola transacción server-side
+
+Un endpoint **por área** que cree paciente + 1ª historia + auditorías dentro de
+un único `prisma.$transaction`. Si algo truena, Prisma revierte todo → el
+huérfano es imposible y el rollback de cliente sobra.
+
+### Diseño de API
+
+```
+POST /nutricion/pacientes   → registra paciente + 1ª historia nutricional (atómico)
+POST /medicina/pacientes    → registra paciente + 1ª historia médica (atómico)
+```
+
+Por qué así (resource-oriented, no `POST /createPatientWithHistory`):
+
+- Es un recurso (la colección "pacientes del área"), no una acción imperativa.
+- Hereda `requireArea(AREA)` del router del área (`routes/nutrition.js`,
+  `routes/medicine.js`).
+- Los endpoints existentes (`POST /pacientes`, `POST /{area}/historias-*`) **se
+  conservan** — siguen siendo recursos válidos (crear paciente solo; crear
+  historia para un paciente existente). Solo cambia la orquestación del registro.
+
+**Request body** (nested, sin ambigüedad de a qué entidad pertenece cada campo):
+
+```json
+{
+  "patient": { "nombre": "...", "apellidos": "...", "...": "..." },
+  "historia": { "motivo_consulta": "...", "adicciones": {}, "...": "..." }
+}
+```
+
+> `historia` **sin** `paciente_id` (se inyecta dentro del tx tras crear el paciente).
+
+**Respuestas:**
+
+| Código | Caso                                     |
+| ------ | ---------------------------------------- |
+| `201`  | `{ message, patient, historia }`         |
+| `422`  | `ValidationError` + `fields` (Zod)       |
+| `401`  | sin sesión                               |
+| `403`  | sin área (`requireArea`)                 |
+| `500`  | error inesperado (transacción revertida) |
+
+Sin versionado (consistente con la API interna, que no usa `/v1`).
+
+## Backend
+
+1. **Shared schema** — `shared/schemas/{nutricion,medicina}/patientRegistration.js`:
+
+   ```js
+   import { z } from 'zod'
+   import { patientSchema } from '../medicina/patient.js'
+   import { nutritionHistorySchema } from './nutritionHistory.js'
+
+   export const nutritionRegistrationSchema = z.object({
+     patient: patientSchema,
+     historia: nutritionHistorySchema.omit({ paciente_id: true }),
+   })
+
+   export function validateNutritionRegistration(input) {
+     return nutritionRegistrationSchema.safeParse(input)
+   }
+   ```
+
+   Reutiliza los schemas existentes (cero validación nueva). Actualizar
+   `shared/package.json#exports` si el sub-path no está cubierto.
+
+2. **Controller** — `controllers/nutricion/patientRegistration.js`. Una sola
+   `$transaction` que compone los modelos que **ya reciben `tx`**:
+
+   ```js
+   const result = validateNutritionRegistration(req.body)
+   if (result.error) {
+     return res.status(422).json({
+       error: 'ValidationError',
+       message: 'Datos de registro inválidos',
+       fields: formatZodErrors(result.error),
+     })
+   }
+   const { patient, historia } = result.data
+   try {
+     const data = await prisma.$transaction(async (tx) => {
+       const p = await PatientModel.create(patient, req.session.userId, tx)
+       const h = await NutritionHistoryModel.create({ ...historia, paciente_id: p.id }, tx)
+       await AuditModel.create(
+         {
+           usuario_id: req.session.userId,
+           accion: ACCIONES.CREAR,
+           entidad: ENTIDADES.PACIENTE,
+           objetivo_id: p.id,
+           paciente_id: p.id,
+         },
+         tx
+       )
+       await AuditModel.create(
+         {
+           usuario_id: req.session.userId,
+           accion: ACCIONES.CREAR,
+           entidad: ENTIDADES.HISTORIA_NUTRICION,
+           objetivo_id: h.id,
+           paciente_id: p.id,
+         },
+         tx
+       )
+       return { patient: p, historia: h }
+     })
+     return res.status(201).json({ message: 'Paciente registrado', ...data })
+   } catch (err) {
+     console.error('Error al registrar paciente de nutrición:', err)
+     return res.status(500).json({ error: 'Error al registrar al paciente' })
+   }
+   ```
+
+3. **Route** — montar bajo el router del área (que ya aplica `requireArea`):
+
+   ```js
+   nutritionRouter.use('/pacientes', nutritionPatientRegistrationRouter) // POST /
+   ```
+
+4. **Modelos** — sin cambios: `PatientModel.create(data, userId, tx)` y
+   `NutritionHistoryModel.create(data, tx)` ya aceptan `tx`.
+
+## Frontend
+
+5. **Service** — `registerNutritionPatient(body)` → `POST /nutricion/pacientes`
+   (en `apiNutritionHistory.js` o nuevo `apiNutritionPatient.js`).
+
+6. **Hook** — `useCreatePatientWithNutritionHistory.js` colapsa a **una mutación**:
+
+   ```js
+   mutationFn: ({ patientData, historyData }) =>
+     registerNutritionPatient({ patient: patientData, historia: historyData })
+   ```
+
+   - `splitFormData` se **reutiliza tal cual** (sigue partiendo el form flat en
+     `{ patientData, historyData }`).
+   - Mantener invalidaciones: `['patients']`, `['nutrition-histories']`,
+     `['dashboard-stats']`.
+
+7. **Mapeo de errores 422** — el body es nested, así que `formatZodErrors`
+   emitirá paths `patient.nombre` / `historia.x`. El handler que hace `setError`
+   debe **quitar el prefijo** `patient.` / `historia.` para casar con los campos
+   planos del RHF. (Verificar el shape real que produce `formatZodErrors`.)
+
+## Limpieza para no dejar basura (checklist)
+
+Tras reescribir cada hook:
+
+- [ ] `deletePatient` — quitar el **import** del hook (no la función del service:
+      la usa el flujo de borrado). Verificar otros callers con grep.
+- [ ] `createNutritionHistory` / `createMedicalHistory` (services) — si quedan
+      **sin callers**, borrarlos (se re-agregan cuando exista "nueva historia para
+      paciente existente"). Verificar con grep antes de borrar.
+- [ ] Eliminar el `try/catch` de rollback y el `console.error` de huérfano.
+- [ ] `grep` final de imports/funciones huérfanas en `services/` y `hooks/`.
+
+## Replicar en medicina (mismo patrón)
+
+- `shared/schemas/medicina/patientRegistration.js`
+- `controllers/medicina/patientRegistration.js`
+- `POST /medicina/pacientes`
+- Reescribir `useCreatePatientWithHistory.js`
+- Mismo checklist de limpieza (`createMedicalHistory`, `deletePatient`).
+
+## Tests
+
+- Backend `__tests__/{nutritionPatientRegistration,medicalPatientRegistration}.test.js`:
+  - `201` crea paciente + historia y ambos quedan en DB.
+  - **`422` no crea nada** (prueba de atomicidad: contar pacientes antes/después).
+  - Fallo de historia → **0 pacientes nuevos** (la transacción revierte).
+  - `401` / `403`.
+- Revisar/ajustar tests que asuman el flujo de dos llamadas.
+
+## Rollout
+
+- **No breaking**: los endpoints viejos permanecen; solo el FE deja de encadenar
+  dos llamadas. Se puede mergear sin coordinar despliegues.
+- Orden de commits sugerido:
+  1. shared schemas
+  2. backend nutrición + tests
+  3. backend medicina + tests
+  4. frontend hooks + limpieza

--- a/frontend/src/features/patients/medicina/hooks/useCreatePatientWithHistory.js
+++ b/frontend/src/features/patients/medicina/hooks/useCreatePatientWithHistory.js
@@ -1,29 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { createPatient, deletePatient } from '@services/apiPatient'
-import { createMedicalHistory } from '@services/apiMedicalHistory'
+import { registerMedicalPatient } from '@services/apiMedicalHistory'
 import { toastApiError } from '@lib/ApiError'
 
 export function useCreatePatientWithHistory() {
   const queryClient = useQueryClient()
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: async ({ patientData, historyData }) => {
-      const { patient } = await createPatient(patientData)
-
-      try {
-        await createMedicalHistory({ paciente_id: patient.id, ...historyData })
-      } catch (historyError) {
-        try {
-          await deletePatient(patient.id)
-        } catch (rollbackError) {
-          console.error('Rollback failed, orphan patient:', patient.id, rollbackError)
-        }
-        throw historyError
-      }
-
-      return patient
-    },
+    // Registro atómico server-side: el backend crea paciente + historia en una
+    // sola transacción, así que no hay rollback ni paciente huérfano que manejar.
+    mutationFn: ({ patientData, historyData }) =>
+      registerMedicalPatient({ patient: patientData, historia: historyData }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['patients'] })
       queryClient.invalidateQueries({ queryKey: ['medical-histories'] })
@@ -34,9 +21,7 @@ export function useCreatePatientWithHistory() {
 
   async function register(payload) {
     try {
-      const result = await mutateAsync(payload)
-      // toast.success se maneja en onSuccess via invalidation
-      return result
+      return await mutateAsync(payload)
     } catch (err) {
       toastApiError(err)
       throw err

--- a/frontend/src/features/patients/nutricion/hooks/useCreatePatientWithNutritionHistory.js
+++ b/frontend/src/features/patients/nutricion/hooks/useCreatePatientWithNutritionHistory.js
@@ -1,29 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { createPatient, deletePatient } from '@services/apiPatient'
-import { createNutritionHistory } from '@services/apiNutritionHistory'
+import { registerNutritionPatient } from '@services/apiNutritionHistory'
 import { toastApiError } from '@lib/ApiError'
 
 export function useCreatePatientWithNutritionHistory() {
   const queryClient = useQueryClient()
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: async ({ patientData, historyData }) => {
-      const { patient } = await createPatient(patientData)
-
-      try {
-        await createNutritionHistory({ paciente_id: patient.id, ...historyData })
-      } catch (historyError) {
-        try {
-          await deletePatient(patient.id)
-        } catch (rollbackError) {
-          console.error('Rollback failed, orphan patient:', patient.id, rollbackError)
-        }
-        throw historyError
-      }
-
-      return patient
-    },
+    // Registro atómico server-side: el backend crea paciente + historia en una
+    // sola transacción, así que no hay rollback ni paciente huérfano que manejar.
+    mutationFn: ({ patientData, historyData }) =>
+      registerNutritionPatient({ patient: patientData, historia: historyData }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['patients'] })
       queryClient.invalidateQueries({ queryKey: ['nutrition-histories'] })
@@ -34,8 +21,7 @@ export function useCreatePatientWithNutritionHistory() {
 
   async function register(payload) {
     try {
-      const result = await mutateAsync(payload)
-      return result
+      return await mutateAsync(payload)
     } catch (err) {
       toastApiError(err)
       throw err

--- a/frontend/src/services/apiMedicalHistory.js
+++ b/frontend/src/services/apiMedicalHistory.js
@@ -1,5 +1,14 @@
 import { fetchApi } from '@lib/fetchApi'
 
+// Registro atómico: crea paciente + 1ª historia médica en un solo request.
+export async function registerMedicalPatient(body) {
+  return fetchApi('/medicina/pacientes', {
+    method: 'POST',
+    body,
+    errorMsg: 'Error al registrar al paciente',
+  })
+}
+
 export async function createMedicalHistory(data) {
   return fetchApi('/medicina/historias-medicas', {
     method: 'POST',

--- a/frontend/src/services/apiNutritionHistory.js
+++ b/frontend/src/services/apiNutritionHistory.js
@@ -1,10 +1,11 @@
 import { fetchApi } from '@lib/fetchApi'
 
-export async function createNutritionHistory(data) {
-  return fetchApi('/nutricion/historias-nutricion', {
+// Registro atómico: crea paciente + 1ª historia nutricional en un solo request.
+export async function registerNutritionPatient(body) {
+  return fetchApi('/nutricion/pacientes', {
     method: 'POST',
-    body: data,
-    errorMsg: 'Error al crear historia de nutrición',
+    body,
+    errorMsg: 'Error al registrar al paciente',
   })
 }
 

--- a/shared/schemas/medicina/patientRegistration.js
+++ b/shared/schemas/medicina/patientRegistration.js
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+import { patientSchema } from './patient.js'
+import { medicalHistorySchema } from './medicalHistory.js'
+
+// Registro atómico: paciente + su primera historia médica en un solo body.
+// La historia va sin paciente_id (se inyecta en el servidor tras crear el paciente).
+export const medicalRegistrationSchema = z.object({
+  patient: patientSchema,
+  historia: medicalHistorySchema.omit({ paciente_id: true }),
+})
+
+export function validateMedicalRegistration(input) {
+  return medicalRegistrationSchema.safeParse(input)
+}

--- a/shared/schemas/nutricion/patientRegistration.js
+++ b/shared/schemas/nutricion/patientRegistration.js
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+import { patientSchema } from '../medicina/patient.js'
+import { nutritionHistorySchema } from './nutritionHistory.js'
+
+// Registro atómico: paciente + su primera historia nutricional en un solo body.
+// La historia va sin paciente_id (se inyecta en el servidor tras crear el paciente).
+export const nutritionRegistrationSchema = z.object({
+  patient: patientSchema,
+  historia: nutritionHistorySchema.omit({ paciente_id: true }),
+})
+
+export function validateNutritionRegistration(input) {
+  return nutritionRegistrationSchema.safeParse(input)
+}


### PR DESCRIPTION
## Contexto

> ⚠️ **Stacked sobre #95** (`feat/nutritional-form-connection`). La base de este PR es esa rama; cuando #95 mergee a `main`, retargetear a `main`.

CodeRabbit marcó en #95 que el registro de paciente era **no atómico**: paciente e historia se creaban en dos requests separados con un `deletePatient` de rollback best-effort en el cliente → riesgo de paciente huérfano si la 2ª llamada y el rollback fallaban. Aplicaba igual a medicina y nutrición.

## Solución

Endpoint por área que crea paciente + 1ª historia + auditorías en una sola `prisma.$transaction`:

```
POST /medicina/pacientes
POST /nutricion/pacientes
```

Body: `{ patient, historia }` (historia sin `paciente_id`, se inyecta tras crear el paciente). Si la historia falla, Prisma revierte todo → **huérfano imposible**, sin rollback de cliente.

## Cambios

**Backend**
- `shared/schemas/{medicina,nutricion}/patientRegistration.js` — reutilizan `patientSchema` + el history schema.
- Controllers + routes por área, bajo el `requireArea` existente.
- Reutiliza `PatientModel.create` / `*HistoryModel.create` (ya reciben `tx`).
- Tests de integración: happy path, **atomicidad** (422 no crea paciente), 401/403.

**Frontend**
- Services `registerNutritionPatient` / `registerMedicalPatient`.
- Hooks `useCreatePatientWith[Nutrition]History` → una sola mutación; fuera el encadenado + rollback.
- `splitFormData` se reutiliza intacto.
- Limpieza: borrado `createNutritionHistory` (sin callers).

## Verificación
- Backend: 200/200 tests.
- Lint: 0 errores. Build frontend OK.

## No breaking
Los endpoints viejos (`POST /pacientes`, `POST /{area}/historias-*`) se conservan; solo cambia la orquestación del registro en el FE.