### PR TITLE
feat(nutrición): evaluación antropométrica + nav lateral de la historia clínica

### DIFF
--- a/frontend/src/features/patients/components/HistoriaPeriodSelect.jsx
+++ b/frontend/src/features/patients/components/HistoriaPeriodSelect.jsx
@@ -2,7 +2,7 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 
 export default function HistoriaPeriodSelect({ value, onChange, periodos }) {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select value={value} onValueChange={onChange} clearable={false}>
       <SelectTrigger className="">
         <SelectValue />
       </SelectTrigger>

--- a/frontend/src/features/patients/components/PatientHistoriaShell.jsx
+++ b/frontend/src/features/patients/components/PatientHistoriaShell.jsx
@@ -149,9 +149,10 @@ export default function PatientHistoriaShell({
 
       <Tab variant="underline" value={activeTab} onValueChange={setActiveTab}>
         {grouped ? (
-          <div className="flex items-start gap-4 max-sm:flex-col max-sm:items-stretch">
-            <aside className="shadow-card sticky top-4 w-56 shrink-0 self-start rounded-2xl border border-gray-100 bg-white p-3 max-sm:static max-sm:w-full">
-              <nav className="space-y-6">
+          <div className="flex items-start gap-4 max-md:flex-col max-md:items-stretch">
+            <aside className="shadow-card sticky top-4 w-56 shrink-0 self-start rounded-2xl border border-gray-100 bg-white p-3 max-md:static max-md:w-full max-md:p-2">
+              {/* Desktop: nav vertical agrupada */}
+              <nav className="space-y-6 max-md:hidden">
                 {buildGroups(tabs).map((g) => (
                   <div key={g.label}>
                     <p className="text-7 mb-1.5 px-3 font-semibold tracking-wider text-zinc-400 uppercase">
@@ -177,6 +178,26 @@ export default function PatientHistoriaShell({
                       ))}
                     </div>
                   </div>
+                ))}
+              </nav>
+              {/* Tablet/mobile: tira horizontal scrollable con todos los items */}
+              <nav className="hidden max-md:flex max-md:gap-1 max-md:overflow-x-auto max-md:pb-0.5">
+                {tabs.map((t) => (
+                  <button
+                    key={t.value}
+                    type="button"
+                    aria-current={activeTab === t.value ? 'page' : undefined}
+                    onClick={() => setActiveTab(t.value)}
+                    data-testid={`tab-${t.value}`}
+                    className={cn(
+                      'text-5 shrink-0 rounded-lg px-3 py-2 whitespace-nowrap transition-colors',
+                      activeTab === t.value
+                        ? 'bg-green-50 text-green-700'
+                        : 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800'
+                    )}
+                  >
+                    {t.label}
+                  </button>
                 ))}
               </nav>
             </aside>

--- a/frontend/src/features/patients/components/PatientHistoriaShell.jsx
+++ b/frontend/src/features/patients/components/PatientHistoriaShell.jsx
@@ -8,6 +8,22 @@ import Tab from '@components/Tab'
 import Button from '@components/Button'
 import Modal from '@components/Modal'
 import HistoriaPeriodSelect from '@features/patients/components/HistoriaPeriodSelect'
+import { cn } from '@lib/utils'
+
+// Agrupa las tabs por su `group` preservando el orden de primera aparición.
+function buildGroups(tabs) {
+  const order = []
+  const byGroup = new Map()
+  for (const t of tabs) {
+    const g = t.group ?? ''
+    if (!byGroup.has(g)) {
+      byGroup.set(g, [])
+      order.push(g)
+    }
+    byGroup.get(g).push(t)
+  }
+  return order.map((label) => ({ label, tabs: byGroup.get(label) }))
+}
 
 // Estructura compartida de la pestaña de historia (selector de período + modales
 // editar/nueva + tabs clínicas + estados de carga/error/vacío). Lo área-específico
@@ -34,9 +50,37 @@ export default function PatientHistoriaShell({
   setActiveTab,
   initialStep,
 }) {
+  const grouped = tabs.some((t) => t.group)
+  // Un tab `bare` muestra su contenido sin la card (ej. Notas, que ya son cards).
+  const activeBare = tabs.find((t) => t.value === activeTab)?.bare
+
+  const tabContent = isLoading ? (
+    <div className="space-y-3 py-2">
+      {['85%', '70%', '92%', '55%'].map((w, i) => (
+        <div key={i} className="h-5 animate-pulse rounded bg-zinc-100" style={{ width: w }} />
+      ))}
+    </div>
+  ) : isError ? (
+    <div className="flex flex-col items-center gap-2 py-12 text-center">
+      <HiOutlineExclamationCircle size={26} className="text-red-300" />
+      <p className="text-5 text-zinc-500">{errorMessage}</p>
+    </div>
+  ) : !historia ? (
+    <div className="flex flex-col items-center gap-2 py-12 text-center">
+      <HiOutlineClipboardDocument size={26} className="text-zinc-300" />
+      <p className="text-5 text-zinc-500">{emptyMessage}</p>
+    </div>
+  ) : (
+    tabs.map((t) => (
+      <Tab.Panel key={t.value} value={t.value} scrollable={false}>
+        {t.render(historia, patient)}
+      </Tab.Panel>
+    ))
+  )
+
   return (
     <div>
-      <div className="mb-4 flex items-center justify-between gap-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
         <div className="flex items-center gap-2">
           {!isLoadingList && periodos.length > 0 && (
             <>
@@ -82,68 +126,84 @@ export default function PatientHistoriaShell({
         </div>
       </div>
 
-      <div className="shadow-card rounded-2xl border border-gray-100 bg-white">
-        <Modal.Content name="edit-history" size="xl" noPadding>
-          {historia && patient && (
-            <FormComponent
-              patient={patient}
-              historia={historia}
-              historiaOnly
-              initialStep={initialStep}
-            />
-          )}
-        </Modal.Content>
+      <Modal.Content name="edit-history" size="xl" noPadding>
+        {historia && patient && (
+          <FormComponent
+            patient={patient}
+            historia={historia}
+            historiaOnly
+            initialStep={initialStep}
+          />
+        )}
+      </Modal.Content>
 
-        <Modal.Content name="new-history" size="xl" noPadding>
-          {patient && !isLoadingCloneBase && (
-            <FormComponent
-              patient={patient}
-              cloneHistoria={cloneBase ?? {}}
-              onCreated={handleSelectHistory}
-            />
-          )}
-        </Modal.Content>
+      <Modal.Content name="new-history" size="xl" noPadding>
+        {patient && !isLoadingCloneBase && (
+          <FormComponent
+            patient={patient}
+            cloneHistoria={cloneBase ?? {}}
+            onCreated={handleSelectHistory}
+          />
+        )}
+      </Modal.Content>
 
-        <Tab variant="underline" value={activeTab} onValueChange={setActiveTab}>
-          <Tab.List>
-            {tabs.map((t) => (
-              <Tab.Trigger key={t.value} value={t.value}>
-                {t.label}
-              </Tab.Trigger>
-            ))}
-          </Tab.List>
-
-          <div className="p-5">
-            {isLoading ? (
-              <div className="space-y-3 py-2">
-                {['85%', '70%', '92%', '55%'].map((w, i) => (
-                  <div
-                    key={i}
-                    className="h-5 animate-pulse rounded bg-zinc-100"
-                    style={{ width: w }}
-                  />
+      <Tab variant="underline" value={activeTab} onValueChange={setActiveTab}>
+        {grouped ? (
+          <div className="flex items-start gap-4 max-sm:flex-col max-sm:items-stretch">
+            <aside className="shadow-card sticky top-4 w-56 shrink-0 self-start rounded-2xl border border-gray-100 bg-white p-3 max-sm:static max-sm:w-full">
+              <nav className="space-y-6">
+                {buildGroups(tabs).map((g) => (
+                  <div key={g.label}>
+                    <p className="text-7 mb-1.5 px-3 font-semibold tracking-wider text-zinc-400 uppercase">
+                      {g.label}
+                    </p>
+                    <div className="space-y-0.5">
+                      {g.tabs.map((t) => (
+                        <button
+                          key={t.value}
+                          type="button"
+                          aria-current={activeTab === t.value ? 'page' : undefined}
+                          onClick={() => setActiveTab(t.value)}
+                          data-testid={`tab-${t.value}`}
+                          className={cn(
+                            'text-5 flex w-full items-center rounded-lg px-3 py-2 text-left whitespace-nowrap transition-colors',
+                            activeTab === t.value
+                              ? 'bg-green-50 text-green-700'
+                              : 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800'
+                          )}
+                        >
+                          {t.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
                 ))}
-              </div>
-            ) : isError ? (
-              <div className="flex flex-col items-center gap-2 py-12 text-center">
-                <HiOutlineExclamationCircle size={26} className="text-red-300" />
-                <p className="text-5 text-zinc-500">{errorMessage}</p>
-              </div>
-            ) : !historia ? (
-              <div className="flex flex-col items-center gap-2 py-12 text-center">
-                <HiOutlineClipboardDocument size={26} className="text-zinc-300" />
-                <p className="text-5 text-zinc-500">{emptyMessage}</p>
-              </div>
-            ) : (
-              tabs.map((t) => (
-                <Tab.Panel key={t.value} value={t.value} scrollable={false}>
-                  {t.render(historia)}
-                </Tab.Panel>
-              ))
-            )}
+              </nav>
+            </aside>
+            <div
+              className={cn(
+                'min-w-0 flex-1',
+                !activeBare && 'shadow-card rounded-2xl border border-gray-100 bg-white p-5'
+              )}
+            >
+              {tabContent}
+            </div>
           </div>
-        </Tab>
-      </div>
+        ) : (
+          <div
+            className={cn(!activeBare && 'shadow-card rounded-2xl border border-gray-100 bg-white')}
+          >
+            <Tab.List>
+              {tabs.map((t) => (
+                <Tab.Trigger key={t.value} value={t.value}>
+                  {t.label}
+                </Tab.Trigger>
+              ))}
+            </Tab.List>
+            <div className={activeBare ? undefined : 'p-5'}>{tabContent}</div>
+          </div>
+        )}
+      </Tab>
     </div>
   )
 }

--- a/frontend/src/features/patients/medicina/components/NotesPanel.jsx
+++ b/frontend/src/features/patients/medicina/components/NotesPanel.jsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import {
   HiOutlinePlus,
   HiOutlineClipboardDocument,
@@ -11,32 +10,20 @@ import Modal from '@components/Modal'
 import { useUrlState } from '@hooks/useUrlState'
 import { useEvolutionNotes } from '@features/patients/medicina/hooks/useEvolutionNotes'
 import { useEvolutionNote } from '@features/patients/medicina/hooks/useEvolutionNote'
-import { useMedicalHistories } from '@features/patients/medicina/hooks/useMedicalHistories'
-import { formatFecha } from '@lib/dateHelpers'
-import HistoriaPeriodSelect from '@features/patients/components/HistoriaPeriodSelect'
 import NoteCard from '@features/patients/medicina/components/NoteCard'
 import NoteDetail from '@features/patients/medicina/components/NoteDetail'
 import EmptyState from '@components/EmptyState'
 import EvolutionNoteForm from '@features/patients/medicina/forms/EvolutionNoteForm/EvolutionNoteForm'
 
-function formatHistoriaOption(h) {
-  return { value: h.id, label: formatFecha(h.creado_at) }
-}
-
-export default function NotesPanel({ pacienteId, patientGenero }) {
-  // Cambiar de historia resetea la nota seleccionada (podría no existir en el
-  // nuevo período) — es un update compuesto de 3 params en una sola llamada
-  // (evita perder alguno por una carrera entre setSearchParams separados), así
-  // que se queda con setSearchParams crudo en vez de useUrlState.
-  const [, setSearchParams] = useSearchParams()
-  const { histories } = useMedicalHistories(pacienteId)
+// Notas de evolución de la historia médica seleccionada. Vive dentro del sidebar
+// de la historia, así que recibe la historia ya resuelta por el shell (el período
+// se elige arriba); no maneja su propio selector.
+export default function NotesPanel({ historia, patient }) {
+  const historiaId = historia?.id ?? null
+  const patientGenero = patient?.genero
   const [layout, setLayout] = useState('grid')
   const [noteToEditId, setNoteToEditId] = useState(null)
   const [editingStep, setEditingStep] = useState(0)
-
-  const [selectedId] = useUrlState('historia', null)
-  const mostRecentId = histories[0]?.id ?? null
-  const historiaId = selectedId ?? mostRecentId
 
   const { notes, isPending } = useEvolutionNotes(historiaId)
   const [selectedNoteId, setSelectedNoteId] = useUrlState('nota', null)
@@ -44,21 +31,6 @@ export default function NotesPanel({ pacienteId, patientGenero }) {
 
   const { note: selectedNote, isPending: isSelectedPending } = useEvolutionNote(selectedNoteId)
   const { note: noteToEdit } = useEvolutionNote(noteToEditId)
-
-  const periodos = histories.map(formatHistoriaOption)
-
-  function handleSelectHistory(id) {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev)
-        next.set('historia', id)
-        next.delete('nota')
-        next.delete('notaTab')
-        return next
-      },
-      { replace: true }
-    )
-  }
 
   function handleOpenEdit(note, { showDetail = false, step = 0 } = {}) {
     if (showDetail) setSelectedNoteId(note.id)
@@ -75,56 +47,43 @@ export default function NotesPanel({ pacienteId, patientGenero }) {
   return (
     <div>
       <Modal>
-        <div className="mb-4 flex items-center justify-between gap-4">
-          {periodos.length > 0 && (
-            <div className="flex items-center gap-2">
-              <span className="text-6 text-zinc-400">Historia médica</span>
-              <HistoriaPeriodSelect
-                value={historiaId}
-                onChange={handleSelectHistory}
-                periodos={periodos}
-              />
-            </div>
-          )}
-          <div className="flex items-center gap-2">
-            {/* Layout Toggle Buttons */}
-            <div className="flex gap-1 rounded-lg border border-gray-200 p-1">
-              <button
-                type="button"
-                className={`rounded p-2 text-gray-500 transition-colors ${
-                  layout === 'grid' ? 'bg-gray-100 text-gray-700' : 'hover:bg-gray-50'
-                }`}
-                aria-label="Vista en grid"
-                onClick={() => setLayout('grid')}
-              >
-                <HiOutlineSquares2X2 size={16} />
-              </button>
-              <button
-                type="button"
-                className={`rounded p-2 text-gray-500 transition-colors ${
-                  layout === 'list' ? 'bg-gray-100 text-gray-700' : 'hover:bg-gray-50'
-                }`}
-                aria-label="Vista en lista"
-                onClick={() => setLayout('list')}
-              >
-                <HiOutlineListBullet size={16} />
-              </button>
-            </div>
-
-            <Modal.Open opens="create-note">
-              <Button
-                variant="primary"
-                size="md"
-                className="gap-1.5"
-                onClick={() => setNoteToEditId(null)}
-                disabled={!historiaId}
-                data-testid="create-note-btn"
-              >
-                <HiOutlinePlus size={14} />
-                Nueva nota
-              </Button>
-            </Modal.Open>
+        <div className="mb-4 flex items-center justify-start gap-2">
+          <div className="flex gap-1 rounded-lg border border-gray-200 p-1">
+            <button
+              type="button"
+              className={`rounded p-2 text-gray-500 transition-colors ${
+                layout === 'grid' ? 'bg-gray-100 text-gray-700' : 'hover:bg-gray-50'
+              }`}
+              aria-label="Vista en grid"
+              onClick={() => setLayout('grid')}
+            >
+              <HiOutlineSquares2X2 size={16} />
+            </button>
+            <button
+              type="button"
+              className={`rounded p-2 text-gray-500 transition-colors ${
+                layout === 'list' ? 'bg-gray-100 text-gray-700' : 'hover:bg-gray-50'
+              }`}
+              aria-label="Vista en lista"
+              onClick={() => setLayout('list')}
+            >
+              <HiOutlineListBullet size={16} />
+            </button>
           </div>
+
+          <Modal.Open opens="create-note">
+            <Button
+              variant="primary"
+              size="md"
+              className="gap-1.5"
+              onClick={() => setNoteToEditId(null)}
+              disabled={!historiaId}
+              data-testid="create-note-btn"
+            >
+              <HiOutlinePlus size={14} />
+              Nueva nota
+            </Button>
+          </Modal.Open>
           <Modal.Open opens="create-note">
             <button
               ref={openModalRef}

--- a/frontend/src/features/patients/medicina/components/PatientHistoria.jsx
+++ b/frontend/src/features/patients/medicina/components/PatientHistoria.jsx
@@ -12,6 +12,7 @@ import FieldsSection from '@features/patients/shared/sections/FieldsSection'
 import SignosVitalesSection from '@features/patients/medicina/sections/SignosVitalesSection'
 import NoPatologicosSection from '@features/patients/medicina/sections/NoPatologicosSection'
 import ConsultaYPlanSection from '@features/patients/medicina/sections/ConsultaYPlanSection'
+import NotesPanel from '@features/patients/medicina/components/NotesPanel'
 
 // Tab de la vista → step de la modal (CLONE_STEPS: omite Identificación →
 // Heredofamiliares es el step 0).
@@ -26,16 +27,19 @@ const TAB_TO_STEP = {
 
 const TABS = [
   {
+    group: 'Antecedentes',
     value: 'heredofamiliares',
     label: 'Heredofamiliares',
     render: (h) => <FieldsSection fields={buildAntFamFields(h.antecedentes_familiares)} />,
   },
   {
+    group: 'Antecedentes',
     value: 'no-patologicos',
     label: 'No Patológicos',
     render: (h) => <NoPatologicosSection historia={h} />,
   },
   {
+    group: 'Antecedentes',
     value: 'patologicos',
     label: 'Patológicos',
     render: (h) => (
@@ -43,19 +47,30 @@ const TABS = [
     ),
   },
   {
+    group: 'Exploración',
     value: 'aparatos',
     label: 'Aparatos y sistemas',
     render: (h) => <FieldsSection fields={buildAparSistFields(h.aparatos_sistemas)} cols={3} />,
   },
   {
+    group: 'Exploración',
     value: 'exploracion',
     label: 'Exploración física',
     render: (h) => <SignosVitalesSection info={h.informacion_fisica} />,
   },
   {
+    group: 'Consulta',
     value: 'consulta-plan',
     label: 'Consulta y Plan',
     render: (h) => <ConsultaYPlanSection historia={h} />,
+  },
+  {
+    group: 'Seguimiento',
+    value: 'notas',
+    label: 'Notas de evolución',
+    // Sus notas ya son cards; se muestra sin la card de contenido.
+    bare: true,
+    render: (h, patient) => <NotesPanel historia={h} patient={patient} />,
   },
 ]
 
@@ -65,6 +80,9 @@ export default function PatientHistoria({ patient }) {
     useHistory: useMedicalHistory,
     periodField: 'creado_at',
     tabToStep: TAB_TO_STEP,
+    // Las notas viven en el sidebar de la historia: al cambiar de período hay
+    // que soltar la nota/tab seleccionados (podrían no existir en el otro).
+    dependentParams: ['nota', 'notaTab'],
   })
 
   return (

--- a/frontend/src/features/patients/nutricion/components/AntroCard.jsx
+++ b/frontend/src/features/patients/nutricion/components/AntroCard.jsx
@@ -1,0 +1,68 @@
+import { HiOutlinePencilSquare, HiOutlineTrash, HiOutlineScale } from 'react-icons/hi2'
+import { formatFecha } from '@lib/dateHelpers'
+import Button from '@components/Button'
+
+// Card de la lista de evaluaciones antropométricas. El endpoint de lista ya trae
+// los bloques niño/adulto, así que la card resume por fecha, tipo e IMC.
+export default function AntroCard({ evalAntro, onView, onEdit, onDelete }) {
+  const esAdulto = Boolean(evalAntro.eval_antro_ad_adulto_nutricion)
+  const tipo = esAdulto ? 'Adultos' : 'Infantil'
+
+  return (
+    <div
+      onClick={() => onView?.(evalAntro)}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onView?.(evalAntro)
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      data-testid={`antro-card-${evalAntro.id}`}
+      className="group relative flex cursor-pointer flex-col gap-3 rounded-xl border border-zinc-100 bg-white p-4 transition-all duration-150 hover:border-teal-300 hover:shadow-sm"
+    >
+      <div className="absolute top-2.5 right-2.5 flex gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="rounded-lg p-1.5 text-zinc-400 hover:text-zinc-700"
+          aria-label="Editar evaluación antropométrica"
+          onClick={(e) => {
+            e.stopPropagation()
+            onEdit?.(evalAntro)
+          }}
+        >
+          <HiOutlinePencilSquare size={14} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="rounded-lg p-1.5 text-zinc-400 hover:text-red-600"
+          aria-label="Eliminar evaluación antropométrica"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete?.(evalAntro)
+          }}
+        >
+          <HiOutlineTrash size={14} />
+        </Button>
+      </div>
+
+      <div className="flex min-w-0 items-center gap-1.5 pr-14">
+        <HiOutlineScale size={15} className="shrink-0 text-teal-500" />
+        <time className="text-6 truncate font-semibold tracking-wide text-zinc-600 uppercase">
+          {formatFecha(evalAntro.fecha)}
+        </time>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-7 rounded-md bg-zinc-100 px-2 py-0.5 font-medium text-zinc-500">
+          {tipo}
+        </span>
+        {evalAntro.imc != null && <span className="text-7 text-zinc-400">IMC {evalAntro.imc}</span>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/components/PatientHistoriaNutricion.jsx
+++ b/frontend/src/features/patients/nutricion/components/PatientHistoriaNutricion.jsx
@@ -10,6 +10,7 @@ import BioquimicaTab from '@features/patients/nutricion/tabs/BioquimicaTab'
 import ExamFisicaTab from '@features/patients/nutricion/tabs/ExamFisicaTab'
 import Rec24hTab from '@features/patients/nutricion/tabs/Rec24hTab'
 import TpanTab from '@features/patients/nutricion/tabs/TpanTab'
+import AntropometricaTab from '@features/patients/nutricion/tabs/AntropometricaTab'
 import NutricionalTab from '@features/patients/nutricion/tabs/NutricionalTab'
 import FieldsSection from '@features/patients/shared/sections/FieldsSection'
 import RecordTable from '@features/patients/shared/sections/RecordTable'
@@ -27,6 +28,7 @@ const TAB_TO_STEP = { enfermedades: 0, tratamientos: 1, adicciones: 2, sueno: 3,
 
 const TABS = [
   {
+    group: 'Historia',
     value: 'enfermedades',
     label: 'Historia médica',
     render: (historia) => (
@@ -48,6 +50,7 @@ const TABS = [
     ),
   },
   {
+    group: 'Historia',
     value: 'tratamientos',
     label: 'Tratamientos alternativos',
     render: (historia) => (
@@ -63,6 +66,7 @@ const TABS = [
     ),
   },
   {
+    group: 'Historia',
     value: 'adicciones',
     label: 'Adicciones',
     render: (historia) => (
@@ -73,39 +77,52 @@ const TABS = [
     ),
   },
   {
+    group: 'Estilo de vida',
     value: 'sueno',
     label: 'Sueño',
     render: (historia) => <SuenoTab historia={historia} />,
   },
   {
+    group: 'Estilo de vida',
     value: 'af',
     label: 'Actividad física',
     render: (historia) => <ActFisicaTab historia={historia} />,
   },
   {
+    group: 'Evaluaciones',
     value: 'bioquimica',
     label: 'Bioquímica',
     render: (historia) => <BioquimicaTab historia={historia} />,
   },
   {
+    group: 'Evaluaciones',
     value: 'examen',
     label: 'Examen físico',
     render: (historia) => <ExamFisicaTab historia={historia} />,
   },
   {
+    group: 'Evaluaciones',
     value: 'frecuencia',
     label: 'Evaluación nutricional',
     render: (historia) => <NutricionalTab historia={historia} />,
   },
   {
+    group: 'Seguimiento',
     value: 'rec24h',
     label: 'Recordatorio 24h',
     render: (historia) => <Rec24hTab historia={historia} />,
   },
   {
+    group: 'Seguimiento',
     value: 'tpan',
     label: 'TPAN',
     render: (historia) => <TpanTab historia={historia} />,
+  },
+  {
+    group: 'Evaluaciones',
+    value: 'antropometria',
+    label: 'Antropometría',
+    render: (historia, patient) => <AntropometricaTab historia={historia} patient={patient} />,
   },
 ]
 
@@ -127,6 +144,8 @@ export default function PatientHistoriaNutricion({ patient }) {
       'recEval',
       'recTab',
       'tpanEval',
+      'antroEval',
+      'antroTab',
     ],
   })
 

--- a/frontend/src/features/patients/nutricion/constants.js
+++ b/frontend/src/features/patients/nutricion/constants.js
@@ -527,3 +527,126 @@ export const TPAN_HINTS = {
   evidencia_probl: '¿Qué datos evaluados le ayudan a pensar en ese problema nutricio?',
   progreso: 'Si el problema se resolvió o no en el monitoreo.',
 }
+
+// Evaluación antropométrica — catálogos de los selects (valores tal cual se
+// guardan en la DB) y los umbrales clínicos de las sugerencias automáticas.
+export const EDAD_ADULTO = 18
+
+// Interpretación NOM-031 (indicadores de crecimiento pediátrico).
+export const NOM031_OPTIONS = [
+  'Peso muy bajo',
+  'Peso bajo',
+  'Peso adecuado',
+  'Sobrepeso',
+  'Obesidad',
+]
+
+// Diagnóstico antropométrico integral (pediátrico).
+export const DIAGNOSTICO_INTEGRAL_OPTIONS = [
+  'Desnutrición aguda',
+  'Desnutrición crónica',
+  'Eutrófico',
+  'OB-SP',
+]
+
+// Complexión por método Frisancho (segmentado por género).
+export const COMPLEXION_OPTIONS = [
+  'M CH <39.3',
+  'M ME 39.3-42.5',
+  'M GR >42.5',
+  'F CH <36.7',
+  'F ME 36.7-40.2',
+  'F GR >40.2',
+]
+
+// Diagnóstico IMC (adulto).
+export const DIAGNOSTICO_IMC_OPTIONS = ['DES < 18.5', 'SAL 18.5-24.9', 'SP 25.0-29.9', 'OB > 30']
+
+// Diagnóstico índice cintura-cadera (segmentado por género).
+export const DIAGNOSTICO_ICC_OPTIONS = [
+  'H normal 0.78-0.84',
+  'H androide >0.94',
+  'M normal 0.71-0.84',
+  'M androide >0.84',
+  'M ginecoide <0.71',
+]
+
+// Indicadores de riesgo booleanos (se guardan como 0/1).
+export const RIESGO_OPTIONS = [
+  { value: 'true', label: 'Sí' },
+  { value: 'false', label: 'No' },
+]
+
+export function esFemenino(genero) {
+  return genero === 'Femenino'
+}
+
+// Conociendo el género del paciente solo mostramos las opciones que le aplican.
+// Ojo: Frisancho usa 'M'/'F' (Masculino/Femenino) e ICC usa 'H'/'M' (Hombre/Mujer).
+export function complexionOptions(femenino) {
+  const prefix = femenino ? 'F ' : 'M '
+  return COMPLEXION_OPTIONS.filter((o) => o.startsWith(prefix))
+}
+
+export function diagnosticoIccOptions(femenino) {
+  const prefix = femenino ? 'M ' : 'H '
+  return DIAGNOSTICO_ICC_OPTIONS.filter((o) => o.startsWith(prefix))
+}
+
+// Sugerencias auto-seleccionadas (editables). Devuelven la etiqueta exacta del
+// catálogo o '' cuando no hay dato suficiente. Los valores pueden llegar como
+// string vacío desde el form, así que se normalizan a número antes de comparar.
+function toNumOrNull(v) {
+  if (v === '' || v == null) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function suggestDiagnosticoImc(value) {
+  const imc = toNumOrNull(value)
+  if (imc == null) return ''
+  if (imc < 18.5) return 'DES < 18.5'
+  if (imc < 25) return 'SAL 18.5-24.9'
+  if (imc < 30) return 'SP 25.0-29.9'
+  return 'OB > 30'
+}
+
+// Riesgo CV por circunferencia de cintura: mujer >80 cm, hombre >94 cm.
+export function suggestRiesgoCintura(value, femenino) {
+  const cintura = toNumOrNull(value)
+  if (cintura == null) return ''
+  return cintura > (femenino ? 80 : 94) ? 'true' : 'false'
+}
+
+// Riesgo EO/INF por circunferencia de cuello: mujer >34 cm, hombre >37 cm.
+export function suggestRiesgoCuello(value, femenino) {
+  const cuello = toNumOrNull(value)
+  if (cuello == null) return ''
+  return cuello > (femenino ? 34 : 37) ? 'true' : 'false'
+}
+
+export function suggestDiagnosticoIcc(value, femenino) {
+  const icc = toNumOrNull(value)
+  if (icc == null) return ''
+  if (femenino) {
+    // Catálogo femenino contiguo: cubre todo el rango.
+    if (icc < 0.71) return 'M ginecoide <0.71'
+    if (icc > 0.84) return 'M androide >0.84'
+    return 'M normal 0.71-0.84'
+  }
+  // Catálogo masculino con huecos (<0.78 y 0.85-0.94 sin etiqueta): fuera de un
+  // rango definido no se sugiere nada y lo decide el clínico.
+  if (icc > 0.94) return 'H androide >0.94'
+  if (icc >= 0.78 && icc <= 0.84) return 'H normal 0.78-0.84'
+  return ''
+}
+
+export const ANTRO_HINTS = {
+  imc: 'Se calcula automáticamente con el peso sin edema y la estatura (kg/m²).',
+  peso_sin_edema: 'Peso actual menos el líquido retenido por edema.',
+  peso_ideal_por: 'Peso sin edema como porcentaje del peso ideal.',
+  indice_cintura_cadera: 'Circunferencia de cintura entre la de cadera.',
+  riesgo_cv: 'Riesgo cardiovascular por circunferencia de cintura (♀ >80 cm · ♂ >94 cm).',
+  riesgo_eo_inf: 'Riesgo por circunferencia de cuello (♀ >34 cm · ♂ >37 cm).',
+  angulo_fase: 'Se deriva de la resistencia y la reactancia de la bioimpedancia.',
+}

--- a/frontend/src/features/patients/nutricion/constants.js
+++ b/frontend/src/features/patients/nutricion/constants.js
@@ -593,6 +593,19 @@ export function diagnosticoIccOptions(femenino) {
   return DIAGNOSTICO_ICC_OPTIONS.filter((o) => o.startsWith(prefix))
 }
 
+// Umbrales clínicos de riesgo antropométrico — fuente única de verdad para las
+// funciones suggest* y para las referencias visuales en el formulario.
+export const CINTURA_RIESGO_F = 80
+export const CINTURA_RIESGO_M = 94
+export const CUELLO_RIESGO_F = 34
+export const CUELLO_RIESGO_M = 37
+export const ICC_GINECOIDE_F = 0.71
+export const ICC_NORMAL_F_MAX = 0.84
+export const ICC_ANDROIDE_F = 0.84
+export const ICC_NORMAL_M_MIN = 0.78
+export const ICC_NORMAL_M_MAX = 0.84
+export const ICC_ANDROIDE_M = 0.94
+
 // Sugerencias auto-seleccionadas (editables). Devuelven la etiqueta exacta del
 // catálogo o '' cuando no hay dato suficiente. Los valores pueden llegar como
 // string vacío desde el form, así que se normalizan a número antes de comparar.
@@ -611,18 +624,18 @@ export function suggestDiagnosticoImc(value) {
   return 'OB > 30'
 }
 
-// Riesgo CV por circunferencia de cintura: mujer >80 cm, hombre >94 cm.
+// Riesgo CV por circunferencia de cintura.
 export function suggestRiesgoCintura(value, femenino) {
   const cintura = toNumOrNull(value)
   if (cintura == null) return ''
-  return cintura > (femenino ? 80 : 94) ? 'true' : 'false'
+  return cintura > (femenino ? CINTURA_RIESGO_F : CINTURA_RIESGO_M) ? 'true' : 'false'
 }
 
-// Riesgo EO/INF por circunferencia de cuello: mujer >34 cm, hombre >37 cm.
+// Riesgo EO/INF por circunferencia de cuello.
 export function suggestRiesgoCuello(value, femenino) {
   const cuello = toNumOrNull(value)
   if (cuello == null) return ''
-  return cuello > (femenino ? 34 : 37) ? 'true' : 'false'
+  return cuello > (femenino ? CUELLO_RIESGO_F : CUELLO_RIESGO_M) ? 'true' : 'false'
 }
 
 export function suggestDiagnosticoIcc(value, femenino) {
@@ -630,14 +643,14 @@ export function suggestDiagnosticoIcc(value, femenino) {
   if (icc == null) return ''
   if (femenino) {
     // Catálogo femenino contiguo: cubre todo el rango.
-    if (icc < 0.71) return 'M ginecoide <0.71'
-    if (icc > 0.84) return 'M androide >0.84'
+    if (icc < ICC_GINECOIDE_F) return 'M ginecoide <0.71'
+    if (icc > ICC_ANDROIDE_F) return 'M androide >0.84'
     return 'M normal 0.71-0.84'
   }
   // Catálogo masculino con huecos (<0.78 y 0.85-0.94 sin etiqueta): fuera de un
   // rango definido no se sugiere nada y lo decide el clínico.
-  if (icc > 0.94) return 'H androide >0.94'
-  if (icc >= 0.78 && icc <= 0.84) return 'H normal 0.78-0.84'
+  if (icc > ICC_ANDROIDE_M) return 'H androide >0.94'
+  if (icc >= ICC_NORMAL_M_MIN && icc <= ICC_NORMAL_M_MAX) return 'H normal 0.78-0.84'
   return ''
 }
 

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroDetail.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroDetail.jsx
@@ -1,0 +1,180 @@
+import { HiOutlineArrowLeft, HiOutlinePencilSquare, HiOutlineTrash } from 'react-icons/hi2'
+import Tab from '@components/Tab'
+import Button from '@components/Button'
+import FieldsSection from '@features/patients/shared/sections/FieldsSection'
+import { useTabStep } from '@hooks/useTabStep'
+import { formatFecha } from '@lib/dateHelpers'
+
+// Tab del detalle → step de AntropometricaForm (mismo orden que los STEPS ahí).
+const TAB_TO_STEP = { t0: 0, t1: 1, t2: 2 }
+
+function siNo(v) {
+  if (v === true) return 'Sí'
+  if (v === false) return 'No'
+  return null
+}
+
+function adultoSections(base, adulto) {
+  return [
+    {
+      label: 'Estructura y Peso',
+      fields: [
+        { label: 'Estatura (cm)', value: base.estatura },
+        { label: 'Ancho de codo (mm)', value: adulto.codo },
+        { label: 'Frisancho (percentil)', value: adulto.frisancho },
+        { label: 'Complexión', value: adulto.complexion },
+        { label: 'Peso ideal (kg)', value: adulto.pi_kg },
+        { label: 'Peso actual (kg)', value: base.peso_actual },
+        { label: 'Edema / líquido (kg)', value: adulto.edema_liq },
+        { label: 'Peso sin edema (kg)', value: adulto.peso_sin_edema },
+        { label: 'Peso ajustado (kg)', value: adulto.peso_ajustado },
+        { label: '% Peso ideal', value: adulto.peso_ideal_por },
+        { label: 'Diagnóstico PI', value: adulto.diagnostico_pi },
+      ],
+    },
+    {
+      label: 'IMC y Pliegues',
+      fields: [
+        { label: 'IMC (kg/m²)', value: base.imc },
+        { label: 'Diagnóstico IMC', value: adulto.diagnostico_imc },
+        { label: 'PB (cm)', value: base.pb },
+        { label: 'PCB (mm)', value: adulto.pcb },
+        { label: 'PCT (mm)', value: base.pct },
+        { label: 'PCSE (mm)', value: base.pcse },
+        { label: 'PCSI (mm)', value: adulto.pcsi },
+        { label: 'Pantorrilla (cm)', value: base.pantorrilla },
+      ],
+    },
+    {
+      label: 'Riesgo Cardiovascular',
+      fields: [
+        { label: 'Cintura (cm)', value: base.cintura },
+        { label: 'Indicador de riesgo (cintura)', value: siNo(adulto.riesgo_cv) },
+        { label: 'Cadera (cm)', value: adulto.cadera },
+        { label: 'Índice cintura-cadera', value: adulto.indice_cintura_cadera },
+        { label: 'Diagnóstico ICC', value: adulto.diagnostico_icc },
+        { label: 'Cuello (cm)', value: adulto.circuf_cuello },
+        { label: 'Indicador de riesgo (cuello)', value: siNo(adulto.riesgo_eo_inf) },
+      ],
+    },
+  ]
+}
+
+function kidSections(base, kid) {
+  return [
+    {
+      label: 'Mediciones y Pliegues',
+      fields: [
+        { label: 'Peso actual (kg)', value: base.peso_actual },
+        { label: 'Estatura (cm)', value: base.estatura },
+        { label: 'IMC (kg/m²)', value: base.imc },
+        { label: 'DE o percentilas (IMC)', value: kid.percentiles_imc },
+        { label: 'Interpretación (IMC)', value: kid.interpretacion_imc },
+        { label: 'Pantorrilla (cm)', value: base.pantorrilla },
+        { label: 'Cintura (cm)', value: base.cintura },
+        { label: 'DE o percentilas (Cintura)', value: kid.percentiles_cintura },
+        { label: 'PB (cm)', value: base.pb },
+        { label: 'DE o percentilas (PB)', value: kid.percentiles_pb },
+        { label: 'PCT (mm)', value: base.pct },
+        { label: 'DE o percentilas (PCT)', value: kid.percentiles_pct },
+        { label: 'PCSE (mm)', value: base.pcse },
+        { label: 'DE o percentilas (PCSE)', value: kid.percentiles_pcse },
+      ],
+    },
+    {
+      label: 'Indicadores de Crecimiento',
+      fields: [
+        { label: 'Peso/talla', value: kid.peso_para_talla },
+        { label: 'Peso ideal (kg)', value: kid.peso_ideal },
+        { label: 'DE peso/talla', value: kid.desviacion_estandar_peso },
+        { label: 'Interpretación NOM (peso/talla)', value: kid.interpretacion_nom_peso },
+        { label: 'Talla/edad', value: kid.talla_para_edad },
+        { label: 'Talla ideal (cm)', value: kid.talla_ideal },
+        { label: 'DE talla/edad', value: kid.desviacion_estandar_talla },
+        { label: 'Interpretación NOM (talla/edad)', value: kid.interpretacion_nom_talla },
+        { label: 'Peso/edad', value: kid.peso_para_edad },
+        { label: 'DE peso/edad', value: kid.desviacion_estandar_peso_edad },
+        { label: 'Interpretación NOM (peso/edad)', value: kid.interpretacion_nom_peso_edad },
+      ],
+    },
+    {
+      label: 'Diagnóstico y Vector',
+      fields: [
+        { label: 'Diagnóstico integral', value: kid.diagnostico_general },
+        { label: 'Resistencia (Ω)', value: kid.resistencia },
+        { label: 'Reactancia (Ω)', value: kid.reactancia },
+        { label: 'Ángulo de fase (°)', value: kid.angulo_fase },
+        { label: 'Tangente del ángulo', value: kid.tan_angulo_fase },
+      ],
+    },
+  ]
+}
+
+export default function AntroDetail({ evalAntro, onBack, onEdit, onDelete }) {
+  const { activeTab, setActiveTab, initialStep } = useTabStep(TAB_TO_STEP, undefined, 'antroTab')
+  const adulto = evalAntro.eval_antro_ad_adulto_nutricion
+  const esAdulto = Boolean(adulto)
+  const sections = esAdulto
+    ? adultoSections(evalAntro, adulto)
+    : kidSections(evalAntro, evalAntro.eval_antro_ad_kid_nutricion ?? {})
+
+  return (
+    <div data-testid="antro-detail">
+      <div className="mb-4 flex items-center justify-between gap-4 border-b border-gray-100 pb-4">
+        <div className="flex min-w-0 items-center gap-2 text-zinc-500">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex shrink-0 cursor-pointer items-center gap-1.5 text-zinc-400 transition-colors hover:text-zinc-700"
+          >
+            <HiOutlineArrowLeft size={14} />
+            <span className="text-5">Antropometría</span>
+          </button>
+          <span className="text-zinc-300">/</span>
+          <span className="text-5 font-semibold text-zinc-700">{formatFecha(evalAntro.fecha)}</span>
+          <span className="text-7 rounded-md bg-zinc-100 px-2 py-0.5 font-medium text-zinc-500">
+            {esAdulto ? 'Adultos' : 'Infantil'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="md"
+            className="p-2 text-zinc-400 hover:text-red-600"
+            aria-label="Eliminar evaluación antropométrica"
+            onClick={() => onDelete?.(evalAntro)}
+          >
+            <HiOutlineTrash size={16} />
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            className="gap-1.5"
+            onClick={() => onEdit?.(initialStep)}
+          >
+            <HiOutlinePencilSquare size={14} />
+            Editar evaluación
+          </Button>
+        </div>
+      </div>
+
+      <Tab variant="underline" value={activeTab} onValueChange={setActiveTab}>
+        <Tab.List>
+          {sections.map((s, i) => (
+            <Tab.Trigger key={`t${i}`} value={`t${i}`}>
+              {s.label}
+            </Tab.Trigger>
+          ))}
+        </Tab.List>
+
+        <div className="pt-5">
+          {sections.map((s, i) => (
+            <Tab.Panel key={`t${i}`} value={`t${i}`} scrollable={false}>
+              <FieldsSection fields={s.fields} />
+            </Tab.Panel>
+          ))}
+        </div>
+      </Tab>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroFields.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroFields.jsx
@@ -1,0 +1,143 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import FormRow from '@components/FormRow'
+import Input from '@components/Input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@components/Select'
+import { useAutoSuggest } from '@features/patients/nutricion/forms/AntropometricaForm/useAutoSuggest'
+
+// Lee el error anidado por path ('adulto.codo' → errors.adulto.codo.message).
+function errorAt(errors, name) {
+  return name.split('.').reduce((acc, key) => acc?.[key], errors)?.message
+}
+
+// Normaliza opciones: acepta ['A','B'] o [{ value, label }].
+function normalize(options) {
+  return options.map((o) => (typeof o === 'string' ? { value: o, label: o } : o))
+}
+
+export function NumberField({ name, label, placeholder = '0.0', tooltip, unit }) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext()
+  const error = errorAt(errors, name)
+  return (
+    <FormRow
+      htmlFor={name}
+      label={unit ? `${label} (${unit})` : label}
+      tooltip={tooltip}
+      error={error}
+    >
+      <Input
+        {...register(name)}
+        id={name}
+        type="number"
+        step="any"
+        inputMode="decimal"
+        placeholder={placeholder}
+        variant="outline"
+        size="md"
+        hasError={error}
+      />
+    </FormRow>
+  )
+}
+
+export function TextField({ name, label, placeholder, tooltip }) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext()
+  const error = errorAt(errors, name)
+  return (
+    <FormRow htmlFor={name} label={label} tooltip={tooltip} error={error}>
+      <Input
+        {...register(name)}
+        id={name}
+        type="text"
+        placeholder={placeholder}
+        variant="outline"
+        size="md"
+        hasError={error}
+      />
+    </FormRow>
+  )
+}
+
+export function SelectField({ name, label, options, placeholder = 'Seleccionar', tooltip }) {
+  const { control } = useFormContext()
+  return (
+    <FormRow label={label} tooltip={tooltip}>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <Select value={field.value ?? ''} onValueChange={field.onChange} fullWidth>
+            <SelectTrigger size="md">
+              <SelectValue placeholder={placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {normalize(options).map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      />
+    </FormRow>
+  )
+}
+
+// Select con sugerencia automática (editable): rellena `suggested` mientras no
+// se toque a mano.
+export function AutoSelectField({
+  name,
+  label,
+  options,
+  suggested,
+  placeholder = 'Seleccionar',
+  tooltip,
+}) {
+  const { control } = useFormContext()
+  const release = useAutoSuggest(name, suggested)
+  return (
+    <FormRow label={label} tooltip={tooltip}>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <Select
+            value={field.value ?? ''}
+            onValueChange={(v) => {
+              release()
+              field.onChange(v)
+            }}
+            fullWidth
+          >
+            <SelectTrigger size="md">
+              <SelectValue placeholder={placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {normalize(options).map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      />
+    </FormRow>
+  )
+}
+
+// Campo de solo lectura para valores auto-calculados.
+export function AutoField({ label, value, tooltip, unit }) {
+  const display = value == null || value === '' ? '' : `${value}`
+  return (
+    <FormRow label={unit ? `${label} (${unit})` : label} tooltip={tooltip}>
+      <Input value={display} placeholder="Auto" variant="outline" size="md" disabled readOnly />
+    </FormRow>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroFields.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntroFields.jsx
@@ -64,15 +64,19 @@ export function TextField({ name, label, placeholder, tooltip }) {
 }
 
 export function SelectField({ name, label, options, placeholder = 'Seleccionar', tooltip }) {
-  const { control } = useFormContext()
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext()
+  const error = errorAt(errors, name)
   return (
-    <FormRow label={label} tooltip={tooltip}>
+    <FormRow label={label} tooltip={tooltip} error={error}>
       <Controller
         name={name}
         control={control}
         render={({ field }) => (
           <Select value={field.value ?? ''} onValueChange={field.onChange} fullWidth>
-            <SelectTrigger size="md">
+            <SelectTrigger size="md" hasError={error}>
               <SelectValue placeholder={placeholder} />
             </SelectTrigger>
             <SelectContent>
@@ -99,10 +103,14 @@ export function AutoSelectField({
   placeholder = 'Seleccionar',
   tooltip,
 }) {
-  const { control } = useFormContext()
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext()
   const release = useAutoSuggest(name, suggested)
+  const error = errorAt(errors, name)
   return (
-    <FormRow label={label} tooltip={tooltip}>
+    <FormRow label={label} tooltip={tooltip} error={error}>
       <Controller
         name={name}
         control={control}
@@ -115,7 +123,7 @@ export function AutoSelectField({
             }}
             fullWidth
           >
-            <SelectTrigger size="md">
+            <SelectTrigger size="md" hasError={error}>
               <SelectValue placeholder={placeholder} />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntropometricaForm.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/AntropometricaForm.jsx
@@ -1,0 +1,124 @@
+import dayjs from 'dayjs'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { antropometricaFormSchema } from '@schemas/anthropometricEval'
+import { useStepForm } from '@hooks/useStepForm'
+import StepFormShell from '@features/patients/shared/forms/StepFormShell'
+import { useCreateAnthropometricEval } from '@features/patients/nutricion/hooks/useCreateAnthropometricEval'
+import { useUpdateAnthropometricEval } from '@features/patients/nutricion/hooks/useUpdateAnthropometricEval'
+import { EDAD_ADULTO, esFemenino } from '@features/patients/nutricion/constants'
+import {
+  ANTRO_BASE_DEFAULTS,
+  ANTRO_ADULTO_DEFAULTS,
+  ANTRO_KID_DEFAULTS,
+} from '@features/patients/nutricion/forms/AntropometricaForm/formDefaults'
+import {
+  buildAntroPayload,
+  buildEditDefaults,
+} from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import EstructuraPesoStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/adulto/EstructuraPesoStep'
+import ImcPliieguesStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/adulto/ImcPliieguesStep'
+import RiesgoCvStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/adulto/RiesgoCvStep'
+import MedicionesStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/kid/MedicionesStep'
+import IndicadoresStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/kid/IndicadoresStep'
+import DiagnosticoVectorStep from '@features/patients/nutricion/forms/AntropometricaForm/steps/kid/DiagnosticoVectorStep'
+
+const ADULTO = {
+  steps: ['Estructura y Peso', 'IMC y Pliegues', 'Riesgo Cardiovascular'],
+  components: [EstructuraPesoStep, ImcPliieguesStep, RiesgoCvStep],
+}
+
+const KID = {
+  steps: ['Mediciones y Pliegues', 'Indicadores de Crecimiento', 'Diagnóstico y Vector'],
+  components: [MedicionesStep, IndicadoresStep, DiagnosticoVectorStep],
+}
+
+const STEPS_FIELDS = [[], [], []]
+
+function calcAge(fechaNacimiento) {
+  if (!fechaNacimiento) return null
+  return dayjs().diff(dayjs(fechaNacimiento), 'year')
+}
+
+// En edición el tipo (niño/adulto) lo dicta el propio registro; al crear se
+// decide por la edad del paciente.
+function resolveEsAdulto(evalAntro, patient) {
+  if (evalAntro) return Boolean(evalAntro.eval_antro_ad_adulto_nutricion)
+  const edad = calcAge(patient?.fecha_nacimiento)
+  return edad != null && edad >= EDAD_ADULTO
+}
+
+export default function AntropometricaForm({
+  historiaId,
+  evalAntro,
+  patient,
+  initialStep = 0,
+  onCloseModal,
+}) {
+  const { createEval, isCreating } = useCreateAnthropometricEval(historiaId)
+  const { updateEval, isUpdating } = useUpdateAnthropometricEval(historiaId)
+  const isEdit = !!evalAntro
+  const esAdulto = resolveEsAdulto(evalAntro, patient)
+  const femenino = esFemenino(patient?.genero)
+  const variant = esAdulto ? ADULTO : KID
+
+  const defaultValues = isEdit
+    ? buildEditDefaults(evalAntro, esAdulto)
+    : {
+        ...ANTRO_BASE_DEFAULTS,
+        fecha: dayjs(),
+        ...(esAdulto ? { adulto: ANTRO_ADULTO_DEFAULTS } : { kid: ANTRO_KID_DEFAULTS }),
+      }
+
+  const stepForm = useStepForm(
+    variant.steps,
+    STEPS_FIELDS,
+    defaultValues,
+    zodResolver(antropometricaFormSchema),
+    initialStep
+  )
+  const {
+    currStep,
+    methods: {
+      formState: { isDirty },
+    },
+  } = stepForm
+
+  const StepComponent = variant.components[currStep]
+  const titleKind = esAdulto ? 'Adultos' : 'Infantil'
+
+  async function onSubmit(data) {
+    const fecha = data.fecha ? dayjs(data.fecha).format('YYYY-MM-DD') : undefined
+    const payload = buildAntroPayload(data, { esAdulto, historiaId })
+
+    if (isEdit) {
+      const dirtyFields = stepForm.methods.formState.dirtyFields
+      if (!Object.keys(dirtyFields).length) return onCloseModal?.()
+
+      const { historia_paciente_id: _omit, ...rest } = payload
+      await updateEval({ id: evalAntro.id, data: { ...rest, fecha: fecha ?? null } })
+    } else {
+      await createEval({ ...payload, ...(fecha && { fecha }) })
+    }
+    onCloseModal?.()
+  }
+
+  return (
+    <StepFormShell
+      title={
+        isEdit
+          ? `Editar Evaluación Antropométrica ${titleKind}`
+          : `Evaluación Antropométrica ${titleKind}`
+      }
+      submitLabel={isEdit ? 'Actualizar evaluación' : 'Guardar evaluación'}
+      steps={variant.steps}
+      onSubmit={onSubmit}
+      isPending={isEdit ? isUpdating : isCreating}
+      isEdit={isEdit}
+      isDirty={isDirty}
+      onCloseModal={onCloseModal}
+      {...stepForm}
+    >
+      <StepComponent femenino={femenino} />
+    </StepFormShell>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/formDefaults.js
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/formDefaults.js
@@ -1,0 +1,54 @@
+// Campos base (comunes a niño y adulto). `imc` no se edita: se auto-calcula.
+export const ANTRO_BASE_DEFAULTS = {
+  peso_actual: '',
+  estatura: '',
+  pantorrilla: '',
+  cintura: '',
+  pb: '',
+  pct: '',
+  pcse: '',
+}
+
+// Adulto: los auto-calculados (peso sin edema, % peso ideal, ICC) no van aquí;
+// se derivan al enviar. `riesgo_cv`/`riesgo_eo_inf` son strings del Select.
+export const ANTRO_ADULTO_DEFAULTS = {
+  codo: '',
+  frisancho: '',
+  complexion: '',
+  pi_kg: '',
+  edema_liq: '',
+  peso_ajustado: '',
+  diagnostico_pi: '',
+  diagnostico_imc: '',
+  pcb: '',
+  pcsi: '',
+  riesgo_cv: '',
+  cadera: '',
+  diagnostico_icc: '',
+  circuf_cuello: '',
+  riesgo_eo_inf: '',
+}
+
+// Niño: ángulo de fase y tangente no van aquí; se derivan de resistencia/reactancia.
+export const ANTRO_KID_DEFAULTS = {
+  percentiles_imc: '',
+  interpretacion_imc: '',
+  percentiles_cintura: '',
+  percentiles_pb: '',
+  percentiles_pct: '',
+  percentiles_pcse: '',
+  peso_para_talla: '',
+  peso_ideal: '',
+  desviacion_estandar_peso: '',
+  interpretacion_nom_peso: '',
+  talla_para_edad: '',
+  talla_ideal: '',
+  desviacion_estandar_talla: '',
+  interpretacion_nom_talla: '',
+  peso_para_edad: '',
+  desviacion_estandar_peso_edad: '',
+  interpretacion_nom_peso_edad: '',
+  diagnostico_general: '',
+  resistencia: '',
+  reactancia: '',
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/serialize.js
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/serialize.js
@@ -1,0 +1,180 @@
+import dayjs from 'dayjs'
+import { fillDefaults } from '@lib/utils'
+import {
+  ANTRO_BASE_DEFAULTS,
+  ANTRO_ADULTO_DEFAULTS,
+  ANTRO_KID_DEFAULTS,
+} from '@features/patients/nutricion/forms/AntropometricaForm/formDefaults'
+
+export function toNum(v) {
+  if (v === '' || v == null) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+function round(n, decimals = 2) {
+  if (n == null || !Number.isFinite(n)) return null
+  const f = 10 ** decimals
+  return Math.round(n * f) / f
+}
+
+function parseBool(v) {
+  if (v === 'true' || v === true) return true
+  if (v === 'false' || v === false) return false
+  return null
+}
+
+function boolToField(v) {
+  if (v === true) return 'true'
+  if (v === false) return 'false'
+  return ''
+}
+
+// Fórmulas tomadas de la hoja de cálculo clínica: el IMC y el % de peso ideal
+// usan el peso SIN edema, no el peso actual.
+export function computeEstaturaM(estatura) {
+  const cm = toNum(estatura)
+  return cm ? round(cm / 100, 2) : null
+}
+
+export function computePesoSinEdema(pesoActual, edemaLiq) {
+  const peso = toNum(pesoActual)
+  if (peso == null) return null
+  return round(peso - (toNum(edemaLiq) ?? 0), 2)
+}
+
+export function computeImc(peso, estatura) {
+  const p = toNum(peso)
+  const m = computeEstaturaM(estatura)
+  if (p == null || !m) return null
+  return round(p / (m * m), 1)
+}
+
+// En adulto el IMC se calcula con el peso SIN edema (no el peso actual).
+export function computeImcAdulto(pesoActual, edemaLiq, estatura) {
+  return computeImc(computePesoSinEdema(pesoActual, edemaLiq), estatura)
+}
+
+export function computePesoIdealPor(pesoSinEdema, piKg) {
+  const pi = toNum(piKg)
+  if (pesoSinEdema == null || !pi) return null
+  return round((pesoSinEdema * 100) / pi, 1)
+}
+
+export function computeIcc(cintura, cadera) {
+  const c = toNum(cintura)
+  const h = toNum(cadera)
+  if (c == null || !h) return null
+  return round(c / h, 2)
+}
+
+// Bioimpedancia: tangente = reactancia/resistencia; ángulo de fase en grados.
+export function computeVector(resistencia, reactancia) {
+  const r = toNum(resistencia)
+  const x = toNum(reactancia)
+  if (!r || x == null) return { angulo_fase: null, tan_angulo_fase: null }
+  const tan = x / r
+  return {
+    angulo_fase: round(Math.atan(tan) * (180 / Math.PI), 2),
+    tan_angulo_fase: round(tan, 4),
+  }
+}
+
+function buildBase(data) {
+  return {
+    peso_actual: toNum(data.peso_actual),
+    estatura: toNum(data.estatura),
+    pantorrilla: toNum(data.pantorrilla),
+    cintura: toNum(data.cintura),
+    pb: toNum(data.pb),
+    pct: toNum(data.pct),
+    pcse: toNum(data.pcse),
+  }
+}
+
+function buildAdulto(data) {
+  const a = data.adulto ?? {}
+  const pesoSinEdema = computePesoSinEdema(data.peso_actual, a.edema_liq)
+  return {
+    codo: toNum(a.codo),
+    frisancho: toNum(a.frisancho),
+    complexion: a.complexion || null,
+    pi_kg: toNum(a.pi_kg),
+    edema_liq: toNum(a.edema_liq),
+    peso_sin_edema: pesoSinEdema,
+    peso_ajustado: toNum(a.peso_ajustado),
+    peso_ideal_por: computePesoIdealPor(pesoSinEdema, a.pi_kg),
+    diagnostico_pi: a.diagnostico_pi || null,
+    diagnostico_imc: a.diagnostico_imc || null,
+    pcb: toNum(a.pcb),
+    pcsi: toNum(a.pcsi),
+    riesgo_cv: parseBool(a.riesgo_cv),
+    cadera: toNum(a.cadera),
+    indice_cintura_cadera: computeIcc(data.cintura, a.cadera),
+    diagnostico_icc: a.diagnostico_icc || null,
+    circuf_cuello: toNum(a.circuf_cuello),
+    riesgo_eo_inf: parseBool(a.riesgo_eo_inf),
+  }
+}
+
+function buildKid(data) {
+  const k = data.kid ?? {}
+  return {
+    percentiles_imc: toNum(k.percentiles_imc),
+    interpretacion_imc: k.interpretacion_imc || null,
+    percentiles_cintura: toNum(k.percentiles_cintura),
+    percentiles_pb: toNum(k.percentiles_pb),
+    percentiles_pct: toNum(k.percentiles_pct),
+    percentiles_pcse: toNum(k.percentiles_pcse),
+    peso_para_talla: toNum(k.peso_para_talla),
+    peso_ideal: toNum(k.peso_ideal),
+    desviacion_estandar_peso: toNum(k.desviacion_estandar_peso),
+    interpretacion_nom_peso: k.interpretacion_nom_peso || null,
+    talla_para_edad: toNum(k.talla_para_edad),
+    talla_ideal: toNum(k.talla_ideal),
+    desviacion_estandar_talla: toNum(k.desviacion_estandar_talla),
+    interpretacion_nom_talla: k.interpretacion_nom_talla || null,
+    peso_para_edad: toNum(k.peso_para_edad),
+    desviacion_estandar_peso_edad: toNum(k.desviacion_estandar_peso_edad),
+    interpretacion_nom_peso_edad: k.interpretacion_nom_peso_edad || null,
+    diagnostico_general: k.diagnostico_general || null,
+    resistencia: toNum(k.resistencia),
+    reactancia: toNum(k.reactancia),
+    ...computeVector(k.resistencia, k.reactancia),
+  }
+}
+
+export function buildAntroPayload(data, { esAdulto, historiaId }) {
+  const base = buildBase(data)
+  const imc = esAdulto
+    ? computeImcAdulto(data.peso_actual, data.adulto?.edema_liq, data.estatura)
+    : computeImc(data.peso_actual, data.estatura)
+
+  return {
+    historia_paciente_id: historiaId,
+    ...base,
+    imc,
+    ...(esAdulto ? { adulto: buildAdulto(data) } : { kid: buildKid(data) }),
+  }
+}
+
+export function buildEditDefaults(record, esAdulto) {
+  const base = fillDefaults(ANTRO_BASE_DEFAULTS, record)
+  const fecha = record?.fecha ? dayjs(record.fecha) : dayjs()
+
+  if (esAdulto) {
+    const a = record?.eval_antro_ad_adulto_nutricion ?? {}
+    return {
+      ...base,
+      fecha,
+      adulto: {
+        ...fillDefaults(ANTRO_ADULTO_DEFAULTS, a),
+        riesgo_cv: boolToField(a.riesgo_cv),
+        riesgo_eo_inf: boolToField(a.riesgo_eo_inf),
+      },
+    }
+  }
+
+  const k = record?.eval_antro_ad_kid_nutricion ?? {}
+  return { ...base, fecha, kid: fillDefaults(ANTRO_KID_DEFAULTS, k) }
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/EstructuraPesoStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/EstructuraPesoStep.jsx
@@ -1,0 +1,93 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+import Heading from '@components/Heading'
+import FormRow from '@components/FormRow'
+import DatePickerComponent from '@ui/DatePickerComponent'
+import {
+  NumberField,
+  TextField,
+  SelectField,
+  AutoField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import {
+  computeEstaturaM,
+  computePesoSinEdema,
+  computePesoIdealPor,
+} from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import { complexionOptions, ANTRO_HINTS } from '@features/patients/nutricion/constants'
+
+export default function EstructuraPesoStep({ femenino }) {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext()
+  const [estatura, pesoActual, edemaLiq, piKg] = useWatch({
+    control,
+    name: ['estatura', 'peso_actual', 'adulto.edema_liq', 'adulto.pi_kg'],
+  })
+  const estaturaM = computeEstaturaM(estatura)
+  const pesoSinEdema = computePesoSinEdema(pesoActual, edemaLiq)
+  const pesoIdealPor = computePesoIdealPor(pesoSinEdema, piKg)
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Identificación y estructura corporal
+        </Heading>
+
+        <FormRow label="Fecha de monitoreo" error={errors?.fecha?.message}>
+          <DatePickerComponent
+            name="fecha"
+            control={control}
+            birthdate={false}
+            hasError={errors?.fecha?.message}
+          />
+        </FormRow>
+
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="estatura" label="Estatura" unit="cm" />
+          <AutoField label="Estatura" unit="m" value={estaturaM} />
+
+          <NumberField name="adulto.codo" label="Ancho de codo" unit="mm" />
+          <NumberField name="adulto.frisancho" label="Frisancho (percentil)" />
+
+          <SelectField
+            name="adulto.complexion"
+            label="Complexión (método Frisancho)"
+            options={complexionOptions(femenino)}
+          />
+          <NumberField name="adulto.pi_kg" label="Peso ideal" unit="kg" />
+        </div>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Análisis de peso
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="peso_actual" label="Peso actual" unit="kg" />
+          <NumberField name="adulto.edema_liq" label="Edema / líquido diario" unit="kg" />
+
+          <AutoField
+            label="Peso sin edema"
+            unit="kg"
+            value={pesoSinEdema}
+            tooltip={ANTRO_HINTS.peso_sin_edema}
+          />
+          <NumberField name="adulto.peso_ajustado" label="Peso ajustado" unit="kg" />
+
+          <AutoField
+            label="% Peso ideal"
+            value={pesoIdealPor}
+            tooltip={ANTRO_HINTS.peso_ideal_por}
+          />
+          <TextField
+            name="adulto.diagnostico_pi"
+            label="Diagnóstico PI"
+            placeholder="Diagnóstico de peso ideal"
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/ImcPliieguesStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/ImcPliieguesStep.jsx
@@ -1,0 +1,55 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+import Heading from '@components/Heading'
+import {
+  NumberField,
+  AutoField,
+  AutoSelectField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import { computeImcAdulto } from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import {
+  DIAGNOSTICO_IMC_OPTIONS,
+  suggestDiagnosticoImc,
+  ANTRO_HINTS,
+} from '@features/patients/nutricion/constants'
+
+export default function ImcPliieguesStep() {
+  const { control } = useFormContext()
+  const [estatura, pesoActual, edemaLiq] = useWatch({
+    control,
+    name: ['estatura', 'peso_actual', 'adulto.edema_liq'],
+  })
+  const imc = computeImcAdulto(pesoActual, edemaLiq, estatura)
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Índice de masa corporal (IMC)
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <AutoField label="IMC" unit="kg/m²" value={imc} tooltip={ANTRO_HINTS.imc} />
+          <AutoSelectField
+            name="adulto.diagnostico_imc"
+            label="Diagnóstico IMC"
+            options={DIAGNOSTICO_IMC_OPTIONS}
+            suggested={suggestDiagnosticoImc(imc)}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Circunferencias y pliegues cutáneos
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="pb" label="Circunferencia media de brazo / PB" unit="cm" />
+          <NumberField name="adulto.pcb" label="Pliegue cutáneo bicipital / PCB" unit="mm" />
+          <NumberField name="pct" label="Pliegue cutáneo tricipital / PCT" unit="mm" />
+          <NumberField name="pcse" label="Pliegue cutáneo subescapular / PCSE" unit="mm" />
+          <NumberField name="adulto.pcsi" label="Pliegue cutáneo suprailiaco / PCSI" unit="mm" />
+          <NumberField name="pantorrilla" label="Circunferencia de pantorrilla" unit="cm" />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/RiesgoCvStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/RiesgoCvStep.jsx
@@ -1,0 +1,88 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+import Heading from '@components/Heading'
+import {
+  NumberField,
+  AutoField,
+  AutoSelectField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import { computeIcc } from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import {
+  diagnosticoIccOptions,
+  RIESGO_OPTIONS,
+  suggestRiesgoCintura,
+  suggestRiesgoCuello,
+  suggestDiagnosticoIcc,
+  ANTRO_HINTS,
+} from '@features/patients/nutricion/constants'
+
+function Reference({ children }) {
+  return (
+    <p className="text-6 rounded-lg bg-sky-50 px-3 py-2 text-sky-800">
+      <span className="font-semibold">Referencia:</span> {children}
+    </p>
+  )
+}
+
+export default function RiesgoCvStep({ femenino }) {
+  const { control } = useFormContext()
+  const [cintura, cadera, cuello] = useWatch({
+    control,
+    name: ['cintura', 'adulto.cadera', 'adulto.circuf_cuello'],
+  })
+  const icc = computeIcc(cintura, cadera)
+  const sexo = femenino ? '♀' : '♂'
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Riesgo cardiovascular
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="cintura" label="Circunferencia de cintura" unit="cm" />
+          <AutoSelectField
+            name="adulto.riesgo_cv"
+            label="Indicador de riesgo"
+            options={RIESGO_OPTIONS}
+            suggested={suggestRiesgoCintura(cintura, femenino)}
+            tooltip={ANTRO_HINTS.riesgo_cv}
+          />
+          <NumberField name="adulto.cadera" label="Circunferencia de cadera" unit="cm" />
+          <AutoField
+            label="Índice cintura-cadera"
+            value={icc}
+            tooltip={ANTRO_HINTS.indice_cintura_cadera}
+          />
+        </div>
+        <AutoSelectField
+          name="adulto.diagnostico_icc"
+          label="Diagnóstico ICC"
+          options={diagnosticoIccOptions(femenino)}
+          suggested={suggestDiagnosticoIcc(icc, femenino)}
+        />
+        <Reference>
+          Cintura {sexo} &gt;{femenino ? 80 : 94} cm · ICC {sexo} &gt;{femenino ? 0.84 : 0.94}
+        </Reference>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Indicadores adicionales de riesgo
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="adulto.circuf_cuello" label="Circunferencia de cuello" unit="cm" />
+          <AutoSelectField
+            name="adulto.riesgo_eo_inf"
+            label="Indicador de riesgo"
+            options={RIESGO_OPTIONS}
+            suggested={suggestRiesgoCuello(cuello, femenino)}
+            tooltip={ANTRO_HINTS.riesgo_eo_inf}
+          />
+        </div>
+        <Reference>
+          Cuello {sexo} &gt;{femenino ? 34 : 37} cm
+        </Reference>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/RiesgoCvStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/adulto/RiesgoCvStep.jsx
@@ -13,6 +13,12 @@ import {
   suggestRiesgoCuello,
   suggestDiagnosticoIcc,
   ANTRO_HINTS,
+  CINTURA_RIESGO_F,
+  CINTURA_RIESGO_M,
+  CUELLO_RIESGO_F,
+  CUELLO_RIESGO_M,
+  ICC_ANDROIDE_F,
+  ICC_ANDROIDE_M,
 } from '@features/patients/nutricion/constants'
 
 function Reference({ children }) {
@@ -61,7 +67,8 @@ export default function RiesgoCvStep({ femenino }) {
           suggested={suggestDiagnosticoIcc(icc, femenino)}
         />
         <Reference>
-          Cintura {sexo} &gt;{femenino ? 80 : 94} cm · ICC {sexo} &gt;{femenino ? 0.84 : 0.94}
+          Cintura {sexo} &gt;{femenino ? CINTURA_RIESGO_F : CINTURA_RIESGO_M} cm · ICC {sexo} &gt;
+          {femenino ? ICC_ANDROIDE_F : ICC_ANDROIDE_M}
         </Reference>
       </section>
 
@@ -80,7 +87,7 @@ export default function RiesgoCvStep({ femenino }) {
           />
         </div>
         <Reference>
-          Cuello {sexo} &gt;{femenino ? 34 : 37} cm
+          Cuello {sexo} &gt;{femenino ? CUELLO_RIESGO_F : CUELLO_RIESGO_M} cm
         </Reference>
       </section>
     </div>

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/DiagnosticoVectorStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/DiagnosticoVectorStep.jsx
@@ -1,0 +1,77 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+import Heading from '@components/Heading'
+import {
+  NumberField,
+  SelectField,
+  AutoField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import { computeVector } from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import {
+  NOM031_OPTIONS,
+  DIAGNOSTICO_INTEGRAL_OPTIONS,
+  ANTRO_HINTS,
+} from '@features/patients/nutricion/constants'
+
+export default function DiagnosticoVectorStep() {
+  const { control } = useFormContext()
+  const [resistencia, reactancia] = useWatch({
+    control,
+    name: ['kid.resistencia', 'kid.reactancia'],
+  })
+  const { angulo_fase, tan_angulo_fase } = computeVector(resistencia, reactancia)
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Peso para la edad
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="kid.peso_para_edad" label="Valor peso/edad" />
+          <NumberField
+            name="kid.desviacion_estandar_peso_edad"
+            label="Desviación estándar"
+            placeholder="Z-score"
+          />
+          <SelectField
+            name="kid.interpretacion_nom_peso_edad"
+            label="Interpretación NOM-031"
+            options={NOM031_OPTIONS}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Diagnóstico antropométrico general
+        </Heading>
+        <SelectField
+          name="kid.diagnostico_general"
+          label="Diagnóstico integral"
+          placeholder="Seleccionar diagnóstico"
+          options={DIAGNOSTICO_INTEGRAL_OPTIONS}
+        />
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Análisis vectorial (opcional)
+        </Heading>
+        <p className="text-6 -mt-3 text-zinc-400">
+          Bioimpedancia eléctrica para evaluación de composición corporal.
+        </p>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="kid.resistencia" label="Resistencia" unit="Ω" />
+          <NumberField name="kid.reactancia" label="Reactancia" unit="Ω" />
+          <AutoField
+            label="Ángulo de fase"
+            unit="°"
+            value={angulo_fase}
+            tooltip={ANTRO_HINTS.angulo_fase}
+          />
+          <AutoField label="Tangente del ángulo" value={tan_angulo_fase} />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/IndicadoresStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/IndicadoresStep.jsx
@@ -1,0 +1,52 @@
+import Heading from '@components/Heading'
+import {
+  NumberField,
+  SelectField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import { NOM031_OPTIONS } from '@features/patients/nutricion/constants'
+
+export default function IndicadoresStep() {
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Peso para la talla
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="kid.peso_para_talla" label="Valor peso/talla" />
+          <NumberField name="kid.peso_ideal" label="Identificación de peso ideal" unit="kg" />
+          <NumberField
+            name="kid.desviacion_estandar_peso"
+            label="Desviación estándar"
+            placeholder="Z-score"
+          />
+          <SelectField
+            name="kid.interpretacion_nom_peso"
+            label="Interpretación NOM-031"
+            options={NOM031_OPTIONS}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Talla para la edad
+        </Heading>
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="kid.talla_para_edad" label="Valor talla/edad" />
+          <NumberField name="kid.talla_ideal" label="Identificación de talla ideal" unit="cm" />
+          <NumberField
+            name="kid.desviacion_estandar_talla"
+            label="Desviación estándar"
+            placeholder="Z-score"
+          />
+          <SelectField
+            name="kid.interpretacion_nom_talla"
+            label="Interpretación NOM-031"
+            options={NOM031_OPTIONS}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/MedicionesStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/steps/kid/MedicionesStep.jsx
@@ -1,0 +1,96 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+import Heading from '@components/Heading'
+import FormRow from '@components/FormRow'
+import DatePickerComponent from '@ui/DatePickerComponent'
+import {
+  NumberField,
+  TextField,
+  AutoField,
+} from '@features/patients/nutricion/forms/AntropometricaForm/AntroFields'
+import { computeImc } from '@features/patients/nutricion/forms/AntropometricaForm/serialize'
+import { ANTRO_HINTS } from '@features/patients/nutricion/constants'
+
+export default function MedicionesStep() {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext()
+  const [pesoActual, estatura] = useWatch({ control, name: ['peso_actual', 'estatura'] })
+  const imc = computeImc(pesoActual, estatura)
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-5">
+        <Heading as="h4" showBar>
+          Mediciones básicas
+        </Heading>
+
+        <FormRow label="Fecha de evaluación" error={errors?.fecha?.message}>
+          <DatePickerComponent
+            name="fecha"
+            control={control}
+            birthdate={false}
+            hasError={errors?.fecha?.message}
+          />
+        </FormRow>
+
+        <div className="grid grid-cols-3 gap-4 max-sm:grid-cols-1">
+          <NumberField name="peso_actual" label="Peso actual" unit="kg" />
+          <NumberField name="estatura" label="Estatura" unit="cm" />
+          <AutoField label="IMC" unit="kg/m²" value={imc} tooltip={ANTRO_HINTS.imc} />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField
+            name="kid.percentiles_imc"
+            label="DE o percentilas (IMC)"
+            placeholder="Z-score o %"
+          />
+          <TextField
+            name="kid.interpretacion_imc"
+            label="Interpretación (IMC)"
+            placeholder="Interpretación clínica"
+          />
+        </div>
+      </section>
+
+      <section className="space-y-5 border-t border-zinc-100 pt-5">
+        <Heading as="h4" showBar>
+          Circunferencias y pliegues cutáneos
+        </Heading>
+
+        <NumberField name="pantorrilla" label="Circunferencia de pantorrilla" unit="cm" />
+
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          <NumberField name="cintura" label="Circunferencia de cintura" unit="cm" />
+          <NumberField
+            name="kid.percentiles_cintura"
+            label="DE o percentilas (Cintura)"
+            placeholder="Z-score o %"
+          />
+
+          <NumberField name="pb" label="Circunferencia media de brazo / PB" unit="cm" />
+          <NumberField
+            name="kid.percentiles_pb"
+            label="DE o percentilas (PB)"
+            placeholder="Z-score o %"
+          />
+
+          <NumberField name="pct" label="Pliegue cutáneo tricipital / PCT" unit="mm" />
+          <NumberField
+            name="kid.percentiles_pct"
+            label="DE o percentilas (PCT)"
+            placeholder="Z-score o %"
+          />
+
+          <NumberField name="pcse" label="Pliegue cutáneo subescapular / PCSE" unit="mm" />
+          <NumberField
+            name="kid.percentiles_pcse"
+            label="DE o percentilas (PCSE)"
+            placeholder="Z-score o %"
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/patients/nutricion/forms/AntropometricaForm/useAutoSuggest.js
+++ b/frontend/src/features/patients/nutricion/forms/AntropometricaForm/useAutoSuggest.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+// Rellena un campo de diagnóstico con la sugerencia derivada de las mediciones,
+// mientras el usuario no lo edite a mano. Al editar un registro existente el
+// valor guardado se respeta (no coincide con la última sugerencia). Devuelve un
+// marcador que el Select llama al cambiar para "soltar" el auto-relleno.
+export function useAutoSuggest(name, suggested) {
+  const { setValue, getValues } = useFormContext()
+  const lastSuggested = useRef(undefined)
+  const overridden = useRef(false)
+
+  useEffect(() => {
+    if (overridden.current) return
+    const current = getValues(name)
+    const isAuto = current === '' || current == null || current === lastSuggested.current
+    if (isAuto && suggested !== '' && suggested != null) {
+      lastSuggested.current = suggested
+      setValue(name, suggested, { shouldDirty: false })
+    }
+  }, [suggested, name, setValue, getValues])
+
+  return () => {
+    overridden.current = true
+  }
+}

--- a/frontend/src/features/patients/nutricion/hooks/useAnthropometricEval.js
+++ b/frontend/src/features/patients/nutricion/hooks/useAnthropometricEval.js
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAnthropometricEvalById } from '@services/apiAntropometrica'
+
+export function useAnthropometricEval(id) {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['antro', id],
+    queryFn: () => getAnthropometricEvalById(id),
+    enabled: Boolean(id),
+  })
+
+  return { evalAntro: data ?? null, isPending, isError, error }
+}

--- a/frontend/src/features/patients/nutricion/hooks/useAnthropometricEvals.js
+++ b/frontend/src/features/patients/nutricion/hooks/useAnthropometricEvals.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAnthropometricEvals } from '@services/apiAntropometrica'
+
+// Se monta solo al entrar al tab de antropometría (Tab.Panel desmonta los tabs
+// inactivos), así que el fetch no carga la vista inicial del paciente.
+export function useAnthropometricEvals(historiaId) {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['antro-list', historiaId],
+    queryFn: () => getAnthropometricEvals(historiaId),
+    enabled: !!historiaId,
+  })
+
+  return { evals: data?.evals ?? [], isPending, isError, error }
+}

--- a/frontend/src/features/patients/nutricion/hooks/useCreateAnthropometricEval.js
+++ b/frontend/src/features/patients/nutricion/hooks/useCreateAnthropometricEval.js
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { createAnthropometricEval } from '@services/apiAntropometrica'
+import { toastApiError } from '@lib/ApiError'
+
+export function useCreateAnthropometricEval(historiaId) {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: createEval, isPending: isCreating } = useMutation({
+    mutationFn: (data) => createAnthropometricEval(data),
+    onSuccess: () => {
+      toast.success('Evaluación antropométrica registrada')
+      queryClient.invalidateQueries({ queryKey: ['antro-list', historiaId] })
+    },
+    onError: toastApiError,
+  })
+
+  return { createEval, isCreating }
+}

--- a/frontend/src/features/patients/nutricion/hooks/useDeleteAnthropometricEval.js
+++ b/frontend/src/features/patients/nutricion/hooks/useDeleteAnthropometricEval.js
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { deleteAnthropometricEval } from '@services/apiAntropometrica'
+import { toastApiError } from '@lib/ApiError'
+
+export function useDeleteAnthropometricEval(historiaId) {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending: isDeleting } = useMutation({
+    mutationFn: (id) => deleteAnthropometricEval(id),
+    onSuccess: (_, id) => {
+      toast.success('Evaluación antropométrica eliminada')
+      queryClient.invalidateQueries({ queryKey: ['antro-list', historiaId] })
+      queryClient.removeQueries({ queryKey: ['antro', id] })
+    },
+    onError: toastApiError,
+  })
+
+  return { deleteEval: mutateAsync, isDeleting }
+}

--- a/frontend/src/features/patients/nutricion/hooks/useUpdateAnthropometricEval.js
+++ b/frontend/src/features/patients/nutricion/hooks/useUpdateAnthropometricEval.js
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { updateAnthropometricEval } from '@services/apiAntropometrica'
+import { toastApiError } from '@lib/ApiError'
+
+export function useUpdateAnthropometricEval(historiaId) {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: updateEval, isPending: isUpdating } = useMutation({
+    mutationFn: ({ id, data }) => updateAnthropometricEval(id, data),
+    onSuccess: (_, { id }) => {
+      toast.success('Evaluación antropométrica actualizada')
+      queryClient.invalidateQueries({ queryKey: ['antro-list', historiaId] })
+      queryClient.invalidateQueries({ queryKey: ['antro', id] })
+    },
+    onError: toastApiError,
+  })
+
+  return { updateEval, isUpdating }
+}

--- a/frontend/src/features/patients/nutricion/tabs/AntropometricaTab.jsx
+++ b/frontend/src/features/patients/nutricion/tabs/AntropometricaTab.jsx
@@ -1,0 +1,39 @@
+import { HiOutlineScale } from 'react-icons/hi2'
+import EndpointEvalTab from '@features/patients/nutricion/tabs/EndpointEvalTab'
+import AntroCard from '@features/patients/nutricion/components/AntroCard'
+import AntroDetail from '@features/patients/nutricion/forms/AntropometricaForm/AntroDetail'
+import AntropometricaForm from '@features/patients/nutricion/forms/AntropometricaForm/AntropometricaForm'
+import { useAnthropometricEvals } from '@features/patients/nutricion/hooks/useAnthropometricEvals'
+import { useAnthropometricEval } from '@features/patients/nutricion/hooks/useAnthropometricEval'
+import { useDeleteAnthropometricEval } from '@features/patients/nutricion/hooks/useDeleteAnthropometricEval'
+
+const CONFIG = {
+  urlParam: 'antroEval',
+  itemProp: 'evalAntro',
+  useList: useAnthropometricEvals,
+  listKey: 'evals',
+  useItem: useAnthropometricEval,
+  itemKey: 'evalAntro',
+  useDelete: useDeleteAnthropometricEval,
+  deleteKey: 'deleteEval',
+  Card: AntroCard,
+  Detail: AntroDetail,
+  Form: AntropometricaForm,
+  icon: HiOutlineScale,
+  title: 'Evaluación Antropométrica',
+  formName: 'antro-form',
+  deleteName: 'delete-antro',
+  deleteTitle: 'Eliminar evaluación antropométrica',
+  listSkeletonHeight: 'h-[96px]',
+  messages: {
+    loadError: 'No se pudo cargar la evaluación antropométrica',
+    listError: 'No se pudieron cargar las evaluaciones antropométricas',
+    emptyMessage: 'Sin evaluaciones antropométricas',
+    emptyHint: 'Registra la primera evaluación de esta historia.',
+    editError: 'No se pudo cargar la evaluación a editar',
+  },
+}
+
+export default function AntropometricaTab({ historia, patient }) {
+  return <EndpointEvalTab historia={historia} patient={patient} config={CONFIG} />
+}

--- a/frontend/src/features/patients/nutricion/tabs/EndpointEvalTab.jsx
+++ b/frontend/src/features/patients/nutricion/tabs/EndpointEvalTab.jsx
@@ -24,7 +24,7 @@ import DangerConfirm from '@components/DangerConfirm'
 //   deleteTitle              título del confirm de borrado
 //   listSkeletonHeight       alto del skeleton de las cards
 //   messages                 { loadError, listError, emptyMessage, emptyHint, editError }
-export default function EndpointEvalTab({ historia, config }) {
+export default function EndpointEvalTab({ historia, patient, config }) {
   const {
     urlParam,
     itemProp,
@@ -125,6 +125,7 @@ export default function EndpointEvalTab({ historia, config }) {
         ) : (
           <Detail
             {...itemPropFor(selectedItem)}
+            patient={patient}
             onBack={() => setSelectedId(null)}
             onEdit={(step, context) => handleEdit(selectedItem, step, context)}
             onDelete={handleDeleteRequest}
@@ -190,6 +191,7 @@ export default function EndpointEvalTab({ historia, config }) {
           <Form
             key={editingItem?.id ?? `new-${urlParam}`}
             historiaId={historia.id}
+            patient={patient}
             {...itemPropFor(editingId ? editingItem : null)}
             initialStep={editingStep}
             editContext={editingContext}

--- a/frontend/src/features/patients/patientAreaRegistry.jsx
+++ b/frontend/src/features/patients/patientAreaRegistry.jsx
@@ -1,12 +1,7 @@
-import {
-  HiOutlineClipboardDocument,
-  HiOutlinePencilSquare,
-  HiOutlineIdentification,
-} from 'react-icons/hi2'
+import { HiOutlineClipboardDocument, HiOutlineIdentification } from 'react-icons/hi2'
 import { AREAS } from '@cais/shared/constants/users'
 import PersonalDataPanel from '@features/patients/components/PersonalDataPanel'
 import PatientHistoria from '@features/patients/medicina/components/PatientHistoria'
-import NotesPanel from '@features/patients/medicina/components/NotesPanel'
 import MedicalPatientForm from '@features/patients/medicina/forms/MedicalPatientForm/MedicalPatientForm'
 import PatientHistoriaNutricion from '@features/patients/nutricion/components/PatientHistoriaNutricion'
 import NutritionPersonalDataPanel from '@features/patients/nutricion/components/NutritionPersonalDataPanel'
@@ -31,18 +26,11 @@ const PATIENT_AREA = {
         value: 'historia',
         label: 'Historia médica',
         icon: <HiOutlineClipboardDocument size={13} />,
-        // NO incluye 'historia' (el período seleccionado): ese lo comparten
-        // "Historia médica" y "Notas" a propósito, para que al cambiar de tab
-        // sigas viendo el mismo período. Solo se limpia el tab interno.
-        ownedParams: ['historiaTab'],
+        // NO incluye 'historia' (el período): al salir del detalle se conserva.
+        // 'nota'/'notaTab' son de las Notas de evolución, que ahora viven en el
+        // sidebar de la historia, así que se limpian junto con el tab interno.
+        ownedParams: ['historiaTab', 'nota', 'notaTab'],
         render: (patient) => <PatientHistoria patient={patient} />,
-      },
-      {
-        value: 'notas',
-        label: 'Notas de evolución',
-        icon: <HiOutlinePencilSquare size={13} />,
-        ownedParams: ['nota', 'notaTab'],
-        render: (patient) => <NotesPanel pacienteId={patient.id} patientGenero={patient.genero} />,
       },
       makeDatosTab(PersonalDataPanel),
     ],

--- a/frontend/src/schemas/anthropometricEval.js
+++ b/frontend/src/schemas/anthropometricEval.js
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import {
+  anthropometricEvalBaseSchema,
+  evalAntroKidSchema,
+  evalAntroAdultoSchema,
+} from '@cais/shared/schemas/nutricion/anthropometricEval'
+
+// El form decide kid vs adulto por la edad del paciente y envía solo ese bloque.
+// `fecha` llega como dayjs; los indicadores de riesgo como 'true'/'false' desde el
+// Select. El resto reutiliza los rangos numéricos del schema compartido (num()
+// coacciona strings y admite vacíos). Los campos auto-calculados (imc, peso sin
+// edema, %, ICC, ángulo de fase) no viven en el form: se derivan al enviar.
+const adultoFormSchema = evalAntroAdultoSchema
+  .extend({
+    riesgo_cv: z.any().optional(),
+    riesgo_eo_inf: z.any().optional(),
+  })
+  .partial()
+
+export const antropometricaFormSchema = z.object({
+  ...anthropometricEvalBaseSchema.omit({ fecha: true, imc: true }).partial().shape,
+  fecha: z.any().optional(),
+  kid: evalAntroKidSchema.partial().optional(),
+  adulto: adultoFormSchema.optional(),
+})

--- a/frontend/src/services/apiAntropometrica.js
+++ b/frontend/src/services/apiAntropometrica.js
@@ -1,0 +1,39 @@
+import { fetchApi } from '@lib/fetchApi'
+
+const BASE = '/nutricion/evaluacion-antropometrica'
+
+export async function getAnthropometricEvals(historia_paciente_id) {
+  const params = new URLSearchParams({ historia_paciente_id, limit: 50 })
+  return fetchApi(`${BASE}?${params}`, {
+    errorMsg: 'Error al obtener las evaluaciones antropométricas',
+  })
+}
+
+export async function getAnthropometricEvalById(id) {
+  return fetchApi(`${BASE}/${id}`, {
+    errorMsg: 'Error al obtener la evaluación antropométrica',
+  })
+}
+
+export async function createAnthropometricEval(data) {
+  return fetchApi(BASE, {
+    method: 'POST',
+    body: data,
+    errorMsg: 'Error al registrar la evaluación antropométrica',
+  })
+}
+
+export async function updateAnthropometricEval(id, data) {
+  return fetchApi(`${BASE}/${id}`, {
+    method: 'PATCH',
+    body: data,
+    errorMsg: 'Error al actualizar la evaluación antropométrica',
+  })
+}
+
+export async function deleteAnthropometricEval(id) {
+  return fetchApi(`${BASE}/${id}`, {
+    method: 'DELETE',
+    errorMsg: 'Error al eliminar la evaluación antropométrica',
+  })
+}

--- a/shared/schemas/nutricion/anthropometricEval.js
+++ b/shared/schemas/nutricion/anthropometricEval.js
@@ -31,7 +31,7 @@ export const evalAntroKidSchema = z.object({
 
 // eval_antro_ad_adulto_nutricion: evaluación de adulto (18 años en adelante)
 export const evalAntroAdultoSchema = z.object({
-  codo: num({ min: 0, max: 20 }), // diámetro de codo, cm
+  codo: num({ min: 0, max: 100 }), // ancho de codo (biepicondíleo), mm
   frisancho: num({ min: 0, max: 100 }), // percentil de complexión
   complexion: str(20),
   pi_kg: num({ min: 0, max: 300 }), // peso ideal, kg


### PR DESCRIPTION
## Resumen

Agrega el CRUD de **evaluación antropométrica** en nutrición y reorganiza la navegación de la historia clínica (medicina y nutrición) en un **nav lateral agrupado y sticky**. 4 commits atómicos:

1. **feat(pacientes)** — Soporte de nav lateral agrupada y sticky en el shell de historia (compartido). Renderiza sidebar vertical con grupos + cards separadas cuando las tabs declaran `group`; si no, conserva las tabs horizontales. Flag `bare` por tab para omitir la card de contenido. Responsive.
2. **feat(nutrición)** — CRUD de evaluación antropométrica.
3. **refactor(medicina)** — Agrupa la historia y mueve las notas de evolución al sidebar.
4. **fix(pacientes)** — Oculta "limpiar selección" en el selector de historia.

## Evaluación antropométrica

- **Perfil por edad:** el form multi-paso elige infantil/adulto según la edad del paciente y comparte los campos base; en edición el tipo lo dicta el propio registro.
- **Auto-cálculo:** IMC (peso sin edema / talla²), % peso ideal, índice cintura-cadera, ángulo de fase + tangente (bioimpedancia).
- **Auto-sugerencia (editable):** Dx IMC, riesgo CV/EO por umbral y género, Dx ICC. Los catálogos de complexión e ICC se filtran por género; el masculino solo sugiere dentro de rangos definidos.
- **UX:** se eliminó el campo "Género" (se lee del paciente) y la fecha redundante del análisis vectorial; un solo campo de peso ideal.
- Reusa el `EndpointEvalTab` genérico (lista + detalle en 3 tabs + form) y el backend/DB ya existentes.
- Sube el `max` de `codo` a 100 (ancho biepicondíleo en mm) en el schema compartido.

## Notas de evolución (medicina)

Como cada nota pertenece a una historia médica (FK `NOT NULL`), dejan de ser una tab de nivel superior del perfil y pasan al sidebar de la historia (grupo "Seguimiento"), reusando el período ya seleccionado por el shell.

## Verificación

- `pnpm run check` (eslint + prettier) limpio.
- `pnpm run build` OK.
- Backend: 21/21 tests de antropometría en verde.
- CodeRabbit review aplicado (ICC masculino, ARIA del sidebar, `bare` en rama sin-grupos).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funciones**
  * Añadida la pestaña **Antropometría** en la historia nutricional con listado, detalle y formulario por etapas para adultos y pediatría.
  * Incluye cálculos automáticos (IMC, ratios) y apoyo con sugerencias/opciones clínicas.

* **Mejoras**
  * “Historia médica” organiza pestañas por grupos y mejora el manejo de carga/errores dentro del área de pestañas.
  * “Notas de evolución” se basan en la historia seleccionada y se elimina el selector de periodos con limpieza.
  * El selector de periodo ya no permite borrar la selección.
  * Se amplía el rango válido para la medición de **codo**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->