### PR TITLE
feat(pacientes): sincronización de pacientes entre áreas

### DIFF
--- a/backend/prisma/migrations/20260722210314_pacientes_areas/migration.sql
+++ b/backend/prisma/migrations/20260722210314_pacientes_areas/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE `pacientes_areas` (
+    `paciente_id` BINARY(16) NOT NULL,
+    `area_id` INTEGER NOT NULL,
+    `doctor_id` BINARY(16) NOT NULL,
+    `creado_at` DATETIME(0) NULL DEFAULT CURRENT_TIMESTAMP(0),
+
+    INDEX `fk_pa_area`(`area_id`),
+    INDEX `fk_pa_doctor`(`doctor_id`),
+    PRIMARY KEY (`paciente_id`, `area_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `pacientes_areas` ADD CONSTRAINT `fk_pa_paciente` FOREIGN KEY (`paciente_id`) REFERENCES `pacientes`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE `pacientes_areas` ADD CONSTRAINT `fk_pa_area` FOREIGN KEY (`area_id`) REFERENCES `areas`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE `pacientes_areas` ADD CONSTRAINT `fk_pa_doctor` FOREIGN KEY (`doctor_id`) REFERENCES `usuarios`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- Backfill: membresía inicial derivada del área del doctor que creó al paciente
+INSERT INTO `pacientes_areas` (`paciente_id`, `area_id`, `doctor_id`, `creado_at`)
+SELECT p.`id`, u.`area_id`, p.`doctor_id`, p.`creado_at`
+FROM `pacientes` p
+JOIN `usuarios` u ON p.`doctor_id` = u.`id`
+WHERE u.`area_id` IS NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,9 +95,26 @@ model aparatos_sistemas {
 }
 
 model areas {
-  id       Int        @id @default(autoincrement())
-  nombre   String     @unique(map: "nombre") @db.VarChar(100)
-  usuarios usuarios[]
+  id              Int               @id @default(autoincrement())
+  nombre          String            @unique(map: "nombre") @db.VarChar(100)
+  usuarios        usuarios[]
+  pacientes_areas pacientes_areas[]
+}
+
+// Membresía de un paciente en un área (fuente de verdad, permite multi-área).
+// `doctor_id` es el responsable del paciente EN esa área.
+model pacientes_areas {
+  paciente_id Bytes     @db.Binary(16)
+  area_id     Int
+  doctor_id   Bytes     @db.Binary(16)
+  creado_at   DateTime? @default(now()) @db.DateTime(0)
+  pacientes   pacientes @relation(fields: [paciente_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_pa_paciente")
+  areas       areas     @relation(fields: [area_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_pa_area")
+  usuarios    usuarios  @relation(fields: [doctor_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_pa_doctor")
+
+  @@id([paciente_id, area_id])
+  @@index([area_id], map: "fk_pa_area")
+  @@index([doctor_id], map: "fk_pa_doctor")
 }
 
 model entidades {
@@ -442,6 +459,7 @@ model pacientes {
   actualizado_at                DateTime?                       @db.DateTime(0)
   historias_medicas             historias_medicas[]
   historias_pacientes_nutricion historias_pacientes_nutricion[]
+  pacientes_areas               pacientes_areas[]
   usuarios                      usuarios                        @relation(fields: [doctor_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_pacientes_usuario")
   registro_auditoria            registro_auditoria[]
 
@@ -534,6 +552,7 @@ model usuarios {
   invitaciones_registro invitaciones_registro[]
   notas_evolucion       notas_evolucion[]
   pacientes             pacientes[]
+  pacientes_areas       pacientes_areas[]
   password_reset_tokens password_reset_tokens[]
   registro_auditoria    registro_auditoria[]
   areas                 areas?                  @relation(fields: [area_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_usuario_area")

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -849,7 +849,32 @@ async function main() {
   console.log('✓ Pacientes de nutrición insertados')
 
   // ═══════════════════════════════════════════
-  // 13. REGISTRO DE AUDITORÍA
+  // 13. MEMBRESÍAS PACIENTE ↔ ÁREA
+  // ═══════════════════════════════════════════
+  const pacientesConDoctor = await prisma.pacientes.findMany({
+    select: { id: true, doctor_id: true, usuarios: { select: { area_id: true } } },
+  })
+  for (const p of pacientesConDoctor) {
+    if (p.usuarios.area_id == null) continue
+    await prisma.pacientes_areas.upsert({
+      where: { paciente_id_area_id: { paciente_id: p.id, area_id: p.usuarios.area_id } },
+      update: {},
+      create: { paciente_id: p.id, area_id: p.usuarios.area_id, doctor_id: p.doctor_id },
+    })
+  }
+
+  // Jorge queda sincronizado en ambas áreas (medicina + nutrición)
+  const areaNutricion = await prisma.areas.findFirst({ where: { nombre: 'NUTRICION' } })
+  await prisma.pacientes_areas.upsert({
+    where: { paciente_id_area_id: { paciente_id: pacJorgeId, area_id: areaNutricion.id } },
+    update: {},
+    create: { paciente_id: pacJorgeId, area_id: areaNutricion.id, doctor_id: anaToTorresId },
+  })
+
+  console.log('✓ Membresías paciente-área insertadas')
+
+  // ═══════════════════════════════════════════
+  // 14. REGISTRO DE AUDITORÍA
   // ═══════════════════════════════════════════
   const auditCount = await prisma.registro_auditoria.count()
   if (auditCount === 0) {

--- a/backend/src/controllers/patientRegistration.js
+++ b/backend/src/controllers/patientRegistration.js
@@ -2,12 +2,16 @@ import { prisma } from '#config/prisma.js'
 import { PatientModel } from '#models/PatientModel.js'
 import { AuditModel } from '#models/AuditModel.js'
 import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
+import { ForbiddenError } from '#lib/appError.js'
 
 /**
  * Construye un controller de registro atómico (paciente + 1ª historia) por área.
  * Medicina y nutrición solo difieren en el modelo de historia y la entidad
- * auditada, así que el flujo vive aquí una sola vez. La validación del body
- * (`{ patient, historia }`) la aplica el middleware `validate` en la ruta.
+ * auditada, así que el flujo vive aquí una sola vez. La validación del body la
+ * aplica el middleware `validate` en la ruta: `{ patient, historia }` crea un
+ * paciente nuevo; `{ paciente_id, patient?, historia }` sincroniza uno existente
+ * de la otra área (membresía + historia + datos complementarios sin sobrescribir
+ * la ficha existente).
  *
  * @param {object} deps
  * @param {(data: object, userId: string, tx: object) => Promise} deps.createHistory
@@ -16,16 +20,26 @@ import { ACCIONES, ENTIDADES } from '@cais/shared/constants/users'
 export function makePatientRegistrationController({ createHistory, historiaEntidad }) {
   return {
     async create(req, res) {
-      const { patient, historia } = req.body
-      const userId = req.session.userId
+      const { patient, paciente_id, historia } = req.body
+      const { userId, areaId } = req.session
+      if (areaId == null) {
+        throw new ForbiddenError('Área no definida para este usuario')
+      }
 
       const data = await prisma.$transaction(async (tx) => {
-        const p = await PatientModel.create(patient, userId, tx)
+        let p
+        if (paciente_id) {
+          await PatientModel.addArea(paciente_id, areaId, userId, tx)
+          if (patient) await PatientModel.fillMissing(paciente_id, patient, tx)
+          p = await PatientModel.getById(paciente_id, tx)
+        } else {
+          p = await PatientModel.create(patient, userId, areaId, tx)
+        }
         const h = await createHistory({ ...historia, paciente_id: p.id }, userId, tx)
         await AuditModel.create(
           {
             usuario_id: userId,
-            accion: ACCIONES.CREAR,
+            accion: paciente_id ? ACCIONES.ACTUALIZAR : ACCIONES.CREAR,
             entidad: ENTIDADES.PACIENTE,
             objetivo_id: p.id,
             paciente_id: p.id,
@@ -44,7 +58,8 @@ export function makePatientRegistrationController({ createHistory, historiaEntid
         )
         return { patient: p, historia: h }
       })
-      res.status(201).json({ message: 'Paciente registrado', ...data })
+      const message = paciente_id ? 'Paciente sincronizado' : 'Paciente registrado'
+      res.status(201).json({ message, ...data })
     },
   }
 }

--- a/backend/src/controllers/patients.js
+++ b/backend/src/controllers/patients.js
@@ -3,13 +3,16 @@ import { AuditModel } from '#models/AuditModel.js'
 import { parsePagination } from '#lib/paginate.js'
 import { ACCIONES, ENTIDADES, ROLES } from '@cais/shared/constants/users'
 import { prisma } from '#config/prisma.js'
-import { NotFoundError } from '#lib/appError.js'
+import { NotFoundError, ForbiddenError, ConflictError } from '#lib/appError.js'
 import { canAccessPatient } from '#lib/patientAccess.js'
 
 export class PatientController {
   static async create(req, res) {
+    if (req.session.areaId == null) {
+      throw new ForbiddenError('Área no definida para este usuario')
+    }
     const patient = await prisma.$transaction(async (tx) => {
-      const p = await PatientModel.create(req.body, req.session.userId, tx)
+      const p = await PatientModel.create(req.body, req.session.userId, req.session.areaId, tx)
       await AuditModel.create(
         {
           usuario_id: req.session.userId,
@@ -23,6 +26,17 @@ export class PatientController {
       return p
     })
     res.status(201).json({ message: 'Paciente registrado', patient })
+  }
+
+  static async getSimilar(req, res) {
+    if (req.session.areaId == null) {
+      throw new ForbiddenError('Área no definida para este usuario')
+    }
+    const similares = await PatientModel.findSimilar({
+      ...req.validatedQuery,
+      excludeAreaId: req.session.areaId,
+    })
+    res.json({ similares })
   }
 
   static async getAll(req, res) {
@@ -56,6 +70,10 @@ export class PatientController {
       const existing = await PatientModel.getById(id, tx)
       if (!canAccessPatient(existing, req.session)) {
         throw new NotFoundError('el paciente')
+      }
+      // Compartido: solo admin puede el borrado completo.
+      if (existing.areas.length > 1 && req.session.role !== ROLES.ADMIN) {
+        throw new ConflictError('El paciente está sincronizado con otra área')
       }
 
       await PatientModel.delete(id, tx)

--- a/backend/src/lib/patientAccess.js
+++ b/backend/src/lib/patientAccess.js
@@ -2,11 +2,12 @@ import { ROLES } from '@cais/shared/constants/users'
 
 /**
  * Política de acceso a un paciente por área. Admin ve todos; el resto solo los
- * pacientes de su misma área (`doctor_area_id`). Los controllers responden 404
- * en vez de 403 cuando falla, para no revelar la existencia del paciente.
+ * pacientes con membresía en su misma área (`patient.areas`). Los controllers
+ * responden 404 en vez de 403 cuando falla, para no revelar la existencia del
+ * paciente.
  */
 export function canAccessPatient(patient, session) {
   if (!patient) return false
   if (session.role === ROLES.ADMIN) return true
-  return patient.doctor_area_id != null && patient.doctor_area_id === session.areaId
+  return session.areaId != null && patient.areas.includes(session.areaId)
 }

--- a/backend/src/lib/similarity.js
+++ b/backend/src/lib/similarity.js
@@ -1,0 +1,32 @@
+export function normalizeName(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function levenshtein(a, b) {
+  if (a === b) return 0
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i]
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = Math.min(
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      )
+    }
+    prev = curr
+  }
+  return prev[b.length]
+}
+
+/** Similitud [0, 1] entre dos nombres ya normalizados (1 = idénticos). */
+export function nameSimilarity(a, b) {
+  const maxLen = Math.max(a.length, b.length)
+  if (maxLen === 0) return 1
+  return 1 - levenshtein(a, b) / maxLen
+}

--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -29,6 +29,25 @@ export function validate(validateFn) {
 }
 
 /**
+ * Como `validate` pero para `req.query`. En Express 5 `req.query` es de solo
+ * lectura, así que el resultado parseado queda en `req.validatedQuery`.
+ */
+export function validateQuery(validateFn) {
+  return (req, res, next) => {
+    const result = validateFn(req.query)
+    if (result.error) {
+      return res.status(422).json({
+        error: 'ValidationError',
+        message: 'Parámetros inválidos',
+        fields: formatZodErrors(result.error),
+      })
+    }
+    req.validatedQuery = result.data
+    next()
+  }
+}
+
+/**
  * Valida un parámetro de ruta (`req.params[name]`) con un predicado. Responde
  * 422 si no pasa. Se monta con `.all()` sobre `.route('/:id')` para cubrir GET,
  * PATCH y DELETE de un recurso con una sola declaración (antes cada controller

--- a/backend/src/models/PatientModel.js
+++ b/backend/src/models/PatientModel.js
@@ -130,7 +130,6 @@ export class PatientModel {
           none: { area_id: excludeAreaId },
         },
       },
-      take: SIMILAR_PATIENT_LIMIT,
       select: {
         id: true,
         nombre: true,
@@ -154,6 +153,7 @@ export class PatientModel {
       }))
       .filter((c) => c.score >= SIMILAR_PATIENT_THRESHOLD)
       .sort((a, b) => b.score - a.score)
+      .slice(0, SIMILAR_PATIENT_LIMIT)
   }
 
   // Datos complementarios al sincronizar: solo escribe campos que la ficha

--- a/backend/src/models/PatientModel.js
+++ b/backend/src/models/PatientModel.js
@@ -2,23 +2,28 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '#config/prisma.js'
 import { uuidToBuffer, bufferToUUID } from '#lib/uuid.js'
 import { formatDefs } from '#lib/formatDef.js'
-import { PATIENT_SORT_DEFS } from '@cais/shared/constants/patients'
-import { NotFoundError } from '#lib/appError.js'
+import {
+  PATIENT_SORT_DEFS,
+  SIMILAR_PATIENT_THRESHOLD,
+  SIMILAR_PATIENT_LIMIT,
+} from '@cais/shared/constants/patients'
+import { NotFoundError, ConflictError } from '#lib/appError.js'
+import { normalizeName, nameSimilarity } from '#lib/similarity.js'
 
 const includeRelations = {
-  usuarios: true,
+  pacientes_areas: { select: { area_id: true } },
 }
 
 const SORT_OPTIONS = formatDefs(PATIENT_SORT_DEFS)
 
 function formatPatient(u) {
   if (!u) return null
-  const { usuarios, ...rest } = u
+  const { pacientes_areas, ...rest } = u
   return {
     ...rest,
     id: bufferToUUID(u.id),
     doctor_id: bufferToUUID(u.doctor_id),
-    doctor_area_id: usuarios?.area_id ?? null,
+    areas: pacientes_areas.map((pa) => pa.area_id),
   }
 }
 
@@ -27,7 +32,7 @@ export class PatientModel {
     const where = {}
 
     if (areaId != null) {
-      where.usuarios = { area_id: areaId }
+      where.pacientes_areas = { some: { area_id: areaId } }
     }
 
     if (search) {
@@ -95,7 +100,7 @@ export class PatientModel {
     })
   }
 
-  static async create(data, userId, tx = prisma) {
+  static async create(data, userId, areaId, tx = prisma) {
     const patientId = randomUUID()
 
     await tx.pacientes.create({
@@ -103,10 +108,88 @@ export class PatientModel {
         ...data,
         id: uuidToBuffer(patientId),
         doctor_id: uuidToBuffer(userId),
+        pacientes_areas: { create: { area_id: areaId, doctor_id: uuidToBuffer(userId) } },
       },
-      include: includeRelations,
     })
 
     return this.getById(patientId, tx)
+  }
+
+  // Candidatos a sincronizar desde otra área: ancla exacta (fecha de nacimiento
+  // y género) + similitud difusa de nombre. Devuelve solo identidad mínima —
+  // nada clínico ni PII extendida, porque cruza el aislamiento por área.
+  static async findSimilar({ nombre, apellidos, fecha_nacimiento, genero, excludeAreaId }) {
+    const candidates = await prisma.pacientes.findMany({
+      where: {
+        fecha_nacimiento,
+        genero,
+        // Debe pertenecer a alguna área pero no a la del solicitante (excluye
+        // pacientes huérfanos sin membresía, que no son sincronizables).
+        pacientes_areas: {
+          some: {},
+          none: { area_id: excludeAreaId },
+        },
+      },
+      take: SIMILAR_PATIENT_LIMIT,
+      select: {
+        id: true,
+        nombre: true,
+        apellidos: true,
+        fecha_nacimiento: true,
+        genero: true,
+        pacientes_areas: { select: { areas: { select: { nombre: true } } } },
+      },
+    })
+
+    const target = normalizeName(`${nombre} ${apellidos}`)
+    return candidates
+      .map((c) => ({
+        id: bufferToUUID(c.id),
+        nombre: c.nombre,
+        apellidos: c.apellidos,
+        fecha_nacimiento: c.fecha_nacimiento,
+        genero: c.genero,
+        areas: c.pacientes_areas.map((pa) => pa.areas.nombre),
+        score: nameSimilarity(target, normalizeName(`${c.nombre} ${c.apellidos}`)),
+      }))
+      .filter((c) => c.score >= SIMILAR_PATIENT_THRESHOLD)
+      .sort((a, b) => b.score - a.score)
+  }
+
+  // Datos complementarios al sincronizar: solo escribe campos que la ficha
+  // existente tiene vacíos — nunca sobrescribe lo capturado por la otra área.
+  static async fillMissing(id, data, tx = prisma) {
+    const existing = await tx.pacientes.findUnique({ where: { id: uuidToBuffer(id) } })
+    if (!existing) throw new NotFoundError('el paciente')
+
+    const missing = {}
+    for (const [key, value] of Object.entries(data)) {
+      const current = existing[key]
+      if (value != null && value !== '' && (current == null || current === '')) {
+        missing[key] = value
+      }
+    }
+    if (Object.keys(missing).length === 0) return
+
+    await tx.pacientes.update({
+      where: { id: uuidToBuffer(id) },
+      data: { ...missing, actualizado_at: new Date() },
+    })
+  }
+
+  static async addArea(id, areaId, userId, tx = prisma) {
+    const idBuffer = uuidToBuffer(id)
+    const exists = await tx.pacientes.findUnique({ where: { id: idBuffer }, select: { id: true } })
+    if (!exists) throw new NotFoundError('el paciente')
+
+    const already = await tx.pacientes_areas.findUnique({
+      where: { paciente_id_area_id: { paciente_id: idBuffer, area_id: areaId } },
+      select: { area_id: true },
+    })
+    if (already) throw new ConflictError('El paciente ya pertenece a esta área')
+
+    await tx.pacientes_areas.create({
+      data: { paciente_id: idBuffer, area_id: areaId, doctor_id: uuidToBuffer(userId) },
+    })
   }
 }

--- a/backend/src/models/StatsModel.js
+++ b/backend/src/models/StatsModel.js
@@ -64,7 +64,7 @@ export class StatsModel {
 
   static async #countPacientes(scope, period) {
     return prisma.pacientes.count({
-      where: { usuarios: scope.usuariosFilter, creado_at: { gte: period.since } },
+      where: { ...scope.pacientesFilter, creado_at: { gte: period.since } },
     })
   }
 
@@ -78,7 +78,7 @@ export class StatsModel {
     const result = await prisma.pacientes.groupBy({
       by: ['genero'],
       _count: { id: true },
-      where: { usuarios: scope.usuariosFilter, genero: { not: null } },
+      where: { ...scope.pacientesFilter, genero: { not: null } },
     })
     return result.map((r) => ({ genero: r.genero, count: r._count.id }))
   }
@@ -91,7 +91,7 @@ export class StatsModel {
       _count: { id: true },
       // Excluye datos viejos sin capturar (null): no se clasifican como interno
       // para no inflar esa estadística.
-      where: { usuarios: scope.usuariosFilter, es_externo: { not: null } },
+      where: { ...scope.pacientesFilter, es_externo: { not: null } },
     })
     const buckets = { interno: 0, externo: 0 }
     for (const r of result) buckets[r.es_externo ? 'externo' : 'interno'] += r._count.id
@@ -108,9 +108,7 @@ export class StatsModel {
         END AS rango,
         COUNT(*) AS count
       FROM pacientes p
-      JOIN usuarios u ON p.doctor_id = u.id
-      JOIN areas a ON u.area_id = a.id
-      WHERE ${scope.sql('a')}
+      WHERE ${scope.pacientesSql}
         AND p.fecha_nacimiento IS NOT NULL
       GROUP BY rango
       ORDER BY
@@ -219,9 +217,10 @@ function entidadesForScope(scope) {
   return scope.personal ? [] : Object.values(AREA_CONFIG).flat()
 }
 
-// Resuelve el alcance de las stats: filtro de Prisma (`usuariosFilter`) y fragmento
-// SQL crudo (`sql(alias)`) reutilizables por cada query. `alias` es el alias de la
-// tabla `areas` en el query crudo.
+// Resuelve el alcance de las stats. Para queries de auditoría/usuarios:
+// `usuariosFilter` (Prisma) y `sql(alias)` (crudo, alias de la tabla `areas`).
+// Para queries de pacientes: `pacientesFilter` y `pacientesSql` (alias `p`),
+// basados en la membresía `pacientes_areas`.
 function buildScope({ area, userId, role }) {
   if (role === ROLES.PASANTE) {
     const userBuffer = uuidToBuffer(userId)
@@ -230,6 +229,8 @@ function buildScope({ area, userId, role }) {
       personal: true,
       usuariosFilter: { id: userBuffer },
       sql: () => Prisma.sql`u.id = ${userBuffer}`,
+      pacientesFilter: { pacientes_areas: { some: { doctor_id: userBuffer } } },
+      pacientesSql: Prisma.sql`EXISTS (SELECT 1 FROM pacientes_areas pa WHERE pa.paciente_id = p.id AND pa.doctor_id = ${userBuffer})`,
     }
   }
   // El admin no tiene área: ve las stats globales de todas las áreas.
@@ -239,6 +240,8 @@ function buildScope({ area, userId, role }) {
       personal: false,
       usuariosFilter: {},
       sql: () => Prisma.sql`1 = 1`,
+      pacientesFilter: {},
+      pacientesSql: Prisma.sql`1 = 1`,
     }
   }
   return {
@@ -246,6 +249,8 @@ function buildScope({ area, userId, role }) {
     personal: false,
     usuariosFilter: { areas: { nombre: area } },
     sql: (alias) => Prisma.sql`${Prisma.raw(alias)}.nombre = ${area}`,
+    pacientesFilter: { pacientes_areas: { some: { areas: { nombre: area } } } },
+    pacientesSql: Prisma.sql`EXISTS (SELECT 1 FROM pacientes_areas pa JOIN areas ar ON pa.area_id = ar.id WHERE pa.paciente_id = p.id AND ar.nombre = ${area})`,
   }
 }
 

--- a/backend/src/routes/patient.js
+++ b/backend/src/routes/patient.js
@@ -1,8 +1,9 @@
 import { Router } from 'express'
 import { PatientController } from '#controllers/patients.js'
 import { requireAuth } from '#middleware/auth.js'
-import { validate, validateUuidParam } from '#middleware/validate.js'
+import { validate, validateQuery, validateUuidParam } from '#middleware/validate.js'
 import { validatePatient, validatePartialPatient } from '@cais/shared/schemas/medicina/patient'
+import { validateSimilarPatientsQuery } from '@cais/shared/schemas/similarPatients'
 
 export const patientRouter = Router()
 
@@ -12,6 +13,12 @@ patientRouter
   .route('/')
   .get(PatientController.getAll)
   .post(validate(validatePatient), PatientController.create)
+
+patientRouter.get(
+  '/similares',
+  validateQuery(validateSimilarPatientsQuery),
+  PatientController.getSimilar
+)
 
 patientRouter
   .route('/:id')

--- a/frontend/src/features/patients/components/ExternoCheckbox.jsx
+++ b/frontend/src/features/patients/components/ExternoCheckbox.jsx
@@ -1,0 +1,20 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import Checkbox from '@components/Checkbox'
+
+export default function ExternoCheckbox() {
+  const { control } = useFormContext()
+  return (
+    <Controller
+      name="es_externo"
+      control={control}
+      render={({ field }) => (
+        <Checkbox
+          id="es_externo"
+          checked={!!field.value}
+          onChange={(e) => field.onChange(e.target.checked)}
+          label="Paciente externo"
+        />
+      )}
+    />
+  )
+}

--- a/frontend/src/features/patients/components/SimilarPatientsBanner.jsx
+++ b/frontend/src/features/patients/components/SimilarPatientsBanner.jsx
@@ -1,0 +1,84 @@
+import dayjs from 'dayjs'
+import { HiOutlineArrowPathRoundedSquare } from 'react-icons/hi2'
+import { AREA_LABELS } from '@cais/shared/constants/users'
+import { getInitials } from '@lib/utils'
+import Button from '@components/Button'
+import Heading from '@components/Heading'
+import Tag from '@components/Tag'
+
+function CandidateRow({ candidate, onSync }) {
+  const pct = Math.round(candidate.score * 100)
+  const nacimiento = dayjs(candidate.fecha_nacimiento)
+
+  return (
+    <li className="flex items-center gap-4 py-3">
+      <span className="text-6 grid size-10 shrink-0 place-items-center rounded-full bg-green-100 font-medium text-green-800">
+        {getInitials(candidate.nombre, candidate.apellidos)}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-5 truncate font-medium text-gray-800">
+          {candidate.nombre} {candidate.apellidos}
+        </p>
+        <div className="text-6 mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-500">
+          <span>{nacimiento.format('DD/MM/YYYY')}</span>
+          <span aria-hidden>·</span>
+          <span>{dayjs().diff(nacimiento, 'year')} años</span>
+          <span aria-hidden>·</span>
+          <span>{candidate.genero}</span>
+          {candidate.areas.map((area) => (
+            <Tag key={area} type="outline" size="xs">
+              {AREA_LABELS[area] ?? area}
+            </Tag>
+          ))}
+        </div>
+      </div>
+
+      <div className="w-28 shrink-0 max-sm:hidden">
+        <div className="text-7 mb-1.5 flex items-center justify-between text-gray-400">
+          <span>Coincidencia</span>
+          <span className="font-medium text-green-800">{pct}%</span>
+        </div>
+        <div className="h-1 overflow-hidden rounded-full bg-gray-100">
+          <div className="h-full rounded-full bg-green-800" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+
+      <Button size="sm" variant="primary" onClick={() => onSync(candidate)}>
+        <HiOutlineArrowPathRoundedSquare size={15} />
+        Sincronizar
+      </Button>
+    </li>
+  )
+}
+
+export default function SimilarPatientsBanner({ candidates, onSync }) {
+  return (
+    <section
+      role="status"
+      className="shadow-card animate-in fade-in slide-in-from-top-2 mb-6 rounded-2xl border border-green-800/20 bg-gradient-to-r from-green-50/70 via-white to-white p-5 ring-1 ring-green-800/10 duration-300"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <Heading as="h4" showBar required>
+          ¿Ya está registrado en otra área?
+        </Heading>
+        <span className="flex items-center gap-2">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+          <Tag type="pendiente" size="xs">
+            {candidates.length === 1 ? '1 coincidencia' : `${candidates.length} coincidencias`}
+          </Tag>
+        </span>
+      </div>
+      <p className="text-6 mt-1 pl-3 text-gray-500">
+        Encontramos {candidates.length === 1 ? 'un expediente parecido' : 'expedientes parecidos'}{' '}
+        en otra área. Si es la misma persona, sincronízala para no duplicar su registro.
+      </p>
+
+      <ul className="mt-3 divide-y divide-gray-100">
+        {candidates.map((c) => (
+          <CandidateRow key={c.id} candidate={c} onSync={onSync} />
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/features/patients/components/SyncedPatientBanner.jsx
+++ b/frontend/src/features/patients/components/SyncedPatientBanner.jsx
@@ -1,0 +1,43 @@
+import dayjs from 'dayjs'
+import { HiCheck, HiOutlineArrowUturnLeft } from 'react-icons/hi2'
+import { getInitials } from '@lib/utils'
+import Button from '@components/Button'
+import Tag from '@components/Tag'
+
+export default function SyncedPatientBanner({ patient, onUndo }) {
+  return (
+    <section
+      role="status"
+      className="shadow-card animate-in fade-in slide-in-from-top-2 mb-6 flex items-center gap-4 rounded-2xl border border-green-800/20 bg-gradient-to-r from-green-50/70 via-white to-white p-5 ring-1 ring-green-800/10 duration-300"
+    >
+      <span className="relative shrink-0">
+        <span className="text-6 grid size-10 place-items-center rounded-full bg-green-100 font-medium text-green-800">
+          {getInitials(patient.nombre, patient.apellidos)}
+        </span>
+        <span className="absolute -right-0.5 -bottom-0.5 grid size-4 place-items-center rounded-full bg-green-800 text-white ring-2 ring-white">
+          <HiCheck size={10} strokeWidth={3} />
+        </span>
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="text-5 flex flex-wrap items-center gap-2 font-medium text-gray-800">
+          <span className="truncate">
+            {patient.nombre} {patient.apellidos}
+          </span>
+          <Tag type="activo" size="xs">
+            Expediente vinculado
+          </Tag>
+        </div>
+        <p className="text-6 mt-0.5 text-gray-500">
+          {dayjs(patient.fecha_nacimiento).format('DD/MM/YYYY')} · {patient.genero} — los datos ya
+          capturados se conservan del expediente; completa solo los campos propios de tu área.
+        </p>
+      </div>
+
+      <Button size="sm" variant="ghost" onClick={onUndo}>
+        <HiOutlineArrowUturnLeft size={14} />
+        Deshacer
+      </Button>
+    </section>
+  )
+}

--- a/frontend/src/features/patients/constants.js
+++ b/frontend/src/features/patients/constants.js
@@ -1,0 +1,2 @@
+// Espera tras la última tecla antes de consultar pacientes similares.
+export const SIMILAR_PATIENTS_DEBOUNCE_MS = 500

--- a/frontend/src/features/patients/hooks/useSimilarPatients.js
+++ b/frontend/src/features/patients/hooks/useSimilarPatients.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { SIMILAR_PATIENT_MIN_CHARS } from '@cais/shared/constants/patients'
+import { SIMILAR_PATIENTS_DEBOUNCE_MS } from '@features/patients/constants'
+import { getSimilarPatients } from '@services/apiPatient'
+
+// Busca pacientes similares en la otra área cuando los 4 campos ancla están
+// completos. Debounced para no consultar en cada tecla; la consulta se keyea y
+// dispara desde el mismo `debouncedKey` para que no se desincronicen.
+export function useSimilarPatients({ nombre, apellidos, fecha_nacimiento, genero }, enabled) {
+  const fecha = fecha_nacimiento?.isValid?.() ? fecha_nacimiento.format('YYYY-MM-DD') : null
+  const anchorKey =
+    enabled &&
+    nombre?.trim().length >= SIMILAR_PATIENT_MIN_CHARS &&
+    apellidos?.trim().length >= SIMILAR_PATIENT_MIN_CHARS &&
+    fecha &&
+    genero
+      ? `${nombre.trim()}|${apellidos.trim()}|${fecha}|${genero}`
+      : null
+
+  const [debouncedKey, setDebouncedKey] = useState(null)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedKey(anchorKey), SIMILAR_PATIENTS_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [anchorKey])
+
+  const { data } = useQuery({
+    queryKey: ['similar-patients', debouncedKey],
+    queryFn: () => {
+      const [nom, ape, fn, gen] = debouncedKey.split('|')
+      return getSimilarPatients({ nombre: nom, apellidos: ape, fecha_nacimiento: fn, genero: gen })
+    },
+    enabled: Boolean(debouncedKey),
+  })
+
+  return { similares: debouncedKey ? (data?.similares ?? []) : [] }
+}

--- a/frontend/src/features/patients/hooks/useSimilarPatients.js
+++ b/frontend/src/features/patients/hooks/useSimilarPatients.js
@@ -33,5 +33,8 @@ export function useSimilarPatients({ nombre, apellidos, fecha_nacimiento, genero
     enabled: Boolean(debouncedKey),
   })
 
-  return { similares: debouncedKey ? (data?.similares ?? []) : [] }
+  // Solo expone candidatos de la identidad ACTUAL: mientras corre el debounce,
+  // debouncedKey aún apunta a la identidad previa y no debe ofrecerse para sync.
+  const isCurrent = Boolean(anchorKey) && anchorKey === debouncedKey
+  return { similares: isCurrent ? (data?.similares ?? []) : [] }
 }

--- a/frontend/src/features/patients/medicina/forms/MedicalPatientForm/MedicalPatientForm.jsx
+++ b/frontend/src/features/patients/medicina/forms/MedicalPatientForm/MedicalPatientForm.jsx
@@ -1,11 +1,15 @@
+import { useState } from 'react'
 import dayjs from 'dayjs'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { medicalPatientFormSchema } from '@schemas/medicalPatient'
+import { medicalPatientFormSchema, medicalSyncFormSchema } from '@schemas/medicalPatient'
 import { useStepForm } from '@hooks/useStepForm'
 import { pickDirty } from '@lib/utils'
 import { useCreatePatientWithHistory } from '@features/patients/medicina/hooks/useCreatePatientWithHistory'
 import { useCreateMedicalHistory } from '@features/patients/medicina/hooks/useCreateMedicalHistory'
 import { useUpdatePatientWithHistory } from '@features/patients/medicina/hooks/useUpdatePatientWithHistory'
+import { useSimilarPatients } from '@features/patients/hooks/useSimilarPatients'
+import SimilarPatientsBanner from '@features/patients/components/SimilarPatientsBanner'
+import SyncedPatientBanner from '@features/patients/components/SyncedPatientBanner'
 import StepFormShell from '@features/patients/shared/forms/StepFormShell'
 import {
   CLONE_STEPS,
@@ -24,6 +28,7 @@ import {
 import { getFormCopy } from '@features/patients/medicina/forms/MedicalPatientForm/formCopy'
 
 const resolver = zodResolver(medicalPatientFormSchema)
+const syncResolver = zodResolver(medicalSyncFormSchema)
 
 function resolveSteps({ patientOnly, skipPatientStep }) {
   if (patientOnly) return [[STEPS[0]], [STEPS_FIELDS[0]], [STEP_COMPONENTS[0]]]
@@ -43,6 +48,9 @@ export default function MedicalPatientForm({
 }) {
   const isEdit = !!patient && (!!historia || patientOnly)
   const isClone = !isEdit && !!patient && !!cloneHistoria
+  const isNew = !isEdit && !isClone && !patientOnly
+
+  const [syncedPatient, setSyncedPatient] = useState(null)
 
   const { register: registerPatient, isRegistering } = useCreatePatientWithHistory()
   const { createHistory, isCreating } = useCreateMedicalHistory()
@@ -61,10 +69,27 @@ export default function MedicalPatientForm({
   })
 
   const startStep = Math.min(initialStep, activeSteps.length - 1)
-  const stepForm = useStepForm(activeSteps, activeStepsFields, defaultValues, resolver, startStep)
+  const stepForm = useStepForm(
+    activeSteps,
+    activeStepsFields,
+    defaultValues,
+    syncedPatient ? syncResolver : resolver,
+    startStep
+  )
   const { currStep, methods } = stepForm
   const { isDirty } = methods.formState
   const StepComponent = activeStepComponents[currStep]
+
+  const [nombre, apellidos, fechaNacimiento, genero] = methods.watch([
+    'nombre',
+    'apellidos',
+    'fecha_nacimiento',
+    'genero',
+  ])
+  const { similares } = useSimilarPatients(
+    { nombre, apellidos, fecha_nacimiento: fechaNacimiento, genero },
+    isNew && !syncedPatient && currStep === 0
+  )
 
   async function onSubmit(data) {
     if (isEdit) {
@@ -84,6 +109,9 @@ export default function MedicalPatientForm({
       const { historyData } = splitFormData(data)
       const result = await createHistory({ pacienteId: patient.id, historyData })
       onCreated?.(result?.history?.id)
+    } else if (syncedPatient) {
+      const { patientData, historyData } = splitFormData(data)
+      await registerPatient({ pacienteId: syncedPatient.id, patientData, historyData })
     } else {
       const { patientData, historyData } = splitFormData(data)
       await registerPatient({ patientData, historyData })
@@ -114,7 +142,13 @@ export default function MedicalPatientForm({
       onCloseModal={onCloseModal}
       {...stepForm}
     >
-      <StepComponent />
+      {syncedPatient && (
+        <SyncedPatientBanner patient={syncedPatient} onUndo={() => setSyncedPatient(null)} />
+      )}
+      {!syncedPatient && similares.length > 0 && (
+        <SimilarPatientsBanner candidates={similares} onSync={setSyncedPatient} />
+      )}
+      <StepComponent syncMode={!!syncedPatient} />
     </StepFormShell>
   )
 }

--- a/frontend/src/features/patients/medicina/forms/MedicalPatientForm/steps/DatosPersonalesStep.jsx
+++ b/frontend/src/features/patients/medicina/forms/MedicalPatientForm/steps/DatosPersonalesStep.jsx
@@ -5,91 +5,84 @@ import FormRow from '@components/FormRow'
 import Input from '@components/Input'
 import Grid from '@components/Grid'
 import Divider from '@components/Divider'
-import Checkbox from '@components/Checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@components/Select'
 import BirthdayField from '@ui/BirthdayField'
 import PhoneField from '@ui/PhoneField'
+import ExternoCheckbox from '@features/patients/components/ExternoCheckbox'
 
-export default function DatosPersonalesStep() {
+// `syncMode`: al sincronizar con un paciente de otra área se ocultan los campos
+// compartidos (ya capturados) y solo se piden los complementarios de medicina.
+export default function DatosPersonalesStep({ syncMode = false }) {
   const { register, control, formState } = useFormContext()
   const { errors } = formState
 
   return (
     <div className="space-y-6">
       {/* ══ 1 · Información Básica Requerida ══ */}
-      <div className="space-y-4">
-        <Heading as="h3" showBar required>
-          Información Básica Requerida
-        </Heading>
+      {!syncMode && (
+        <div className="space-y-4">
+          <Heading as="h3" showBar required>
+            Información Básica Requerida
+          </Heading>
 
-        <Grid cols={2} gap={4} mobileCols={2}>
-          <FormRow htmlFor="nombre" label="Nombre(s)" required>
-            <Input
-              {...register('nombre')}
-              id="nombre"
-              type="text"
-              placeholder="Ingrese nombre(s)"
-              hasError={errors?.nombre?.message}
-              variant="outline"
-              size="lg"
-            />
-          </FormRow>
-          <FormRow htmlFor="apellidos" label="Apellidos" required>
-            <Input
-              {...register('apellidos')}
-              id="apellidos"
-              type="text"
-              placeholder="Ingrese apellidos"
-              hasError={errors?.apellidos?.message}
-              variant="outline"
-              size="lg"
-            />
-          </FormRow>
-        </Grid>
+          <Grid cols={2} gap={4} mobileCols={2}>
+            <FormRow htmlFor="nombre" label="Nombre(s)" required>
+              <Input
+                {...register('nombre')}
+                id="nombre"
+                type="text"
+                placeholder="Ingrese nombre(s)"
+                hasError={errors?.nombre?.message}
+                variant="outline"
+                size="lg"
+              />
+            </FormRow>
+            <FormRow htmlFor="apellidos" label="Apellidos" required>
+              <Input
+                {...register('apellidos')}
+                id="apellidos"
+                type="text"
+                placeholder="Ingrese apellidos"
+                hasError={errors?.apellidos?.message}
+                variant="outline"
+                size="lg"
+              />
+            </FormRow>
+          </Grid>
 
-        <Grid cols={3} gap={4} mobileCols={2}>
-          <BirthdayField name="fecha_nacimiento" control={control} errors={errors} />
-          <PhoneField />
-          <FormRow label="Género" required error={errors?.genero?.message}>
-            <Controller
-              name="genero"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} fullWidth>
-                  <SelectTrigger size="lg" hasError={errors?.genero?.message}>
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Masculino">Masculino</SelectItem>
-                    <SelectItem value="Femenino">Femenino</SelectItem>
-                    <SelectItem value="Otro">Otro</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          </FormRow>
-        </Grid>
+          <Grid cols={3} gap={4} mobileCols={2}>
+            <BirthdayField name="fecha_nacimiento" control={control} errors={errors} />
+            <PhoneField />
+            <FormRow label="Género" required error={errors?.genero?.message}>
+              <Controller
+                name="genero"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} fullWidth>
+                    <SelectTrigger size="lg" hasError={errors?.genero?.message}>
+                      <SelectValue placeholder="Seleccionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Masculino">Masculino</SelectItem>
+                      <SelectItem value="Femenino">Femenino</SelectItem>
+                      <SelectItem value="Otro">Otro</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormRow>
+          </Grid>
 
-        <Controller
-          name="es_externo"
-          control={control}
-          render={({ field }) => (
-            <Checkbox
-              id="es_externo"
-              checked={!!field.value}
-              onChange={(e) => field.onChange(e.target.checked)}
-              label="Paciente externo"
-            />
-          )}
-        />
-      </div>
+          <ExternoCheckbox />
+        </div>
+      )}
 
-      <Divider />
+      {!syncMode && <Divider />}
 
       {/* ══ 2 · Información Adicional ══ */}
       <div className="space-y-4">
         <Heading as="h3" showBar>
-          Información Adicional
+          {syncMode ? 'Datos complementarios de medicina' : 'Información Adicional'}
         </Heading>
 
         <Grid cols={3} gap={4} mobileCols={2}>
@@ -140,51 +133,53 @@ export default function DatosPersonalesStep() {
           </FormRow>
         </Grid>
 
-        <Grid cols={3} gap={4} mobileCols={2}>
-          <FormRow label="Estado Civil">
-            <Controller
-              name="estado_civil"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} fullWidth>
-                  <SelectTrigger size="lg">
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Soltero/a">Soltero/a</SelectItem>
-                    <SelectItem value="Casado/a">Casado/a</SelectItem>
-                    <SelectItem value="Divorciado/a">Divorciado/a</SelectItem>
-                    <SelectItem value="Viudo/a">Viudo/a</SelectItem>
-                    <SelectItem value="Unión libre">Unión libre</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          </FormRow>
-          <FormRow htmlFor="correo" label="Correo Electrónico">
-            <Input
-              {...register('correo')}
-              id="correo"
-              type="email"
-              placeholder="correo@uabc.edu.mx"
-              hasError={errors?.correo?.message}
-              variant="outline"
-              size="lg"
-              suffix={<HiOutlineEnvelope className="text-zinc-400" />}
-            />
-          </FormRow>
-          <FormRow htmlFor="ocupacion" label="Ocupación">
-            <Input
-              {...register('ocupacion')}
-              id="ocupacion"
-              type="text"
-              placeholder="Ocupación del paciente"
-              hasError={errors?.ocupacion?.message}
-              variant="outline"
-              size="lg"
-            />
-          </FormRow>
-        </Grid>
+        {!syncMode && (
+          <Grid cols={3} gap={4} mobileCols={2}>
+            <FormRow label="Estado Civil">
+              <Controller
+                name="estado_civil"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} fullWidth>
+                    <SelectTrigger size="lg">
+                      <SelectValue placeholder="Seleccionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Soltero/a">Soltero/a</SelectItem>
+                      <SelectItem value="Casado/a">Casado/a</SelectItem>
+                      <SelectItem value="Divorciado/a">Divorciado/a</SelectItem>
+                      <SelectItem value="Viudo/a">Viudo/a</SelectItem>
+                      <SelectItem value="Unión libre">Unión libre</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormRow>
+            <FormRow htmlFor="correo" label="Correo Electrónico">
+              <Input
+                {...register('correo')}
+                id="correo"
+                type="email"
+                placeholder="correo@uabc.edu.mx"
+                hasError={errors?.correo?.message}
+                variant="outline"
+                size="lg"
+                suffix={<HiOutlineEnvelope className="text-zinc-400" />}
+              />
+            </FormRow>
+            <FormRow htmlFor="ocupacion" label="Ocupación">
+              <Input
+                {...register('ocupacion')}
+                id="ocupacion"
+                type="text"
+                placeholder="Ocupación del paciente"
+                hasError={errors?.ocupacion?.message}
+                variant="outline"
+                size="lg"
+              />
+            </FormRow>
+          </Grid>
+        )}
 
         <Grid cols={3} gap={4} mobileCols={2}>
           <FormRow htmlFor="religion" label="Religión">

--- a/frontend/src/features/patients/medicina/hooks/useCreatePatientWithHistory.js
+++ b/frontend/src/features/patients/medicina/hooks/useCreatePatientWithHistory.js
@@ -8,14 +8,19 @@ export function useCreatePatientWithHistory() {
 
   const { mutateAsync, isPending } = useMutation({
     // Registro atómico server-side: el backend crea paciente + historia en una
-    // sola transacción, así que no hay rollback ni paciente huérfano que manejar.
-    mutationFn: ({ patientData, historyData }) =>
-      registerMedicalPatient({ patient: patientData, historia: historyData }),
-    onSuccess: () => {
+    // sola transacción. Con `pacienteId` sincroniza un paciente existente de
+    // otra área en vez de crear uno nuevo.
+    mutationFn: ({ patientData, historyData, pacienteId }) =>
+      registerMedicalPatient(
+        pacienteId
+          ? { paciente_id: pacienteId, patient: patientData, historia: historyData }
+          : { patient: patientData, historia: historyData }
+      ),
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['patients'] })
       queryClient.invalidateQueries({ queryKey: ['medical-histories'] })
       queryClient.invalidateQueries({ queryKey: ['stats'] })
-      toast.success('Paciente registrado correctamente')
+      toast.success(data?.message ?? 'Paciente registrado correctamente')
     },
   })
 

--- a/frontend/src/features/patients/nutricion/forms/NutritionalPatientForm/NutritionalPatientForm.jsx
+++ b/frontend/src/features/patients/nutricion/forms/NutritionalPatientForm/NutritionalPatientForm.jsx
@@ -1,6 +1,13 @@
+import { useState } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { nutritionalPatientFormSchema } from '@schemas/nutritionalPatient'
+import {
+  nutritionalPatientFormSchema,
+  nutritionalSyncFormSchema,
+} from '@schemas/nutritionalPatient'
 import { useStepForm } from '@hooks/useStepForm'
+import { useSimilarPatients } from '@features/patients/hooks/useSimilarPatients'
+import SimilarPatientsBanner from '@features/patients/components/SimilarPatientsBanner'
+import SyncedPatientBanner from '@features/patients/components/SyncedPatientBanner'
 import { useCreatePatientWithNutritionHistory } from '@features/patients/nutricion/hooks/useCreatePatientWithNutritionHistory'
 import { useCreateNutritionHistory } from '@features/patients/nutricion/hooks/useCreateNutritionHistory'
 import { useUpdatePatientWithNutritionHistory } from '@features/patients/nutricion/hooks/useUpdatePatientWithNutritionHistory'
@@ -27,6 +34,7 @@ import {
 import { getFormCopy } from '@features/patients/nutricion/forms/NutritionalPatientForm/formCopy'
 
 const resolver = zodResolver(nutritionalPatientFormSchema)
+const syncResolver = zodResolver(nutritionalSyncFormSchema)
 
 function resolveSteps({ patientOnly, skipPatientStep, historiaOnly }) {
   if (patientOnly) return [[STEPS[0]], [STEPS_FIELDS[0]], [STEP_COMPONENTS[0]]]
@@ -48,6 +56,9 @@ export default function NutritionalPatientForm({
 }) {
   const isEdit = !!patient && (!!historia || patientOnly)
   const isClone = !isEdit && !!patient && !!cloneHistoria
+  const isNew = !isEdit && !isClone && !patientOnly
+
+  const [syncedPatient, setSyncedPatient] = useState(null)
 
   const { register: registerPatient, isRegistering } = useCreatePatientWithNutritionHistory()
   const { createHistory, isCreating } = useCreateNutritionHistory()
@@ -67,10 +78,27 @@ export default function NutritionalPatientForm({
   })
 
   const startStep = Math.min(initialStep, activeSteps.length - 1)
-  const stepForm = useStepForm(activeSteps, activeStepsFields, defaultValues, resolver, startStep)
+  const stepForm = useStepForm(
+    activeSteps,
+    activeStepsFields,
+    defaultValues,
+    syncedPatient ? syncResolver : resolver,
+    startStep
+  )
   const { currStep, methods } = stepForm
   const { isDirty } = methods.formState
   const StepComponent = activeStepComponents[currStep]
+
+  const [nombre, apellidos, fechaNacimiento, genero] = methods.watch([
+    'nombre',
+    'apellidos',
+    'fecha_nacimiento',
+    'genero',
+  ])
+  const { similares } = useSimilarPatients(
+    { nombre, apellidos, fecha_nacimiento: fechaNacimiento, genero },
+    isNew && !syncedPatient && currStep === 0
+  )
 
   async function onSubmit(data) {
     if (isEdit) {
@@ -95,6 +123,9 @@ export default function NutritionalPatientForm({
       const { historyData } = splitFormData(data)
       const result = await createHistory({ pacienteId: patient.id, historyData })
       onCreated?.(result?.history?.id)
+    } else if (syncedPatient) {
+      const { patientData, historyData } = splitFormData(data)
+      await registerPatient({ pacienteId: syncedPatient.id, patientData, historyData })
     } else {
       const { patientData, historyData } = splitFormData(data)
       await registerPatient({ patientData, historyData })
@@ -125,7 +156,13 @@ export default function NutritionalPatientForm({
       onCloseModal={onCloseModal}
       {...stepForm}
     >
-      <StepComponent />
+      {syncedPatient && (
+        <SyncedPatientBanner patient={syncedPatient} onUndo={() => setSyncedPatient(null)} />
+      )}
+      {!syncedPatient && similares.length > 0 && (
+        <SimilarPatientsBanner candidates={similares} onSync={setSyncedPatient} />
+      )}
+      <StepComponent syncMode={!!syncedPatient} />
     </StepFormShell>
   )
 }

--- a/frontend/src/features/patients/nutricion/forms/NutritionalPatientForm/steps/IdentificacionNutrStep.jsx
+++ b/frontend/src/features/patients/nutricion/forms/NutritionalPatientForm/steps/IdentificacionNutrStep.jsx
@@ -8,6 +8,7 @@ import Divider from '@components/Divider'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@components/Select'
 import BirthdayField from '@ui/BirthdayField'
 import PhoneField from '@ui/PhoneField'
+import ExternoCheckbox from '@features/patients/components/ExternoCheckbox'
 import {
   ESCOLARIDAD_OPTIONS,
   OCUPACION_NUTR_OPTIONS,
@@ -15,7 +16,9 @@ import {
   SALARIO_DIA_OPTIONS,
 } from '@features/patients/nutricion/constants'
 
-export default function IdentificacionNutrStep() {
+// `syncMode`: al sincronizar con un paciente de otra área se ocultan los campos
+// compartidos (ya capturados) y solo se piden los complementarios de nutrición.
+export default function IdentificacionNutrStep({ syncMode = false }) {
   const { register, control, formState } = useFormContext()
   const { errors } = formState
 
@@ -24,56 +27,62 @@ export default function IdentificacionNutrStep() {
       {/* ══ 1 · Información Básica Requerida ══ */}
       <div className="space-y-4">
         <Heading as="h3" showBar required>
-          Información Básica Requerida
+          {syncMode ? 'Motivo de consulta' : 'Información Básica Requerida'}
         </Heading>
 
-        <Grid cols={2} gap={4} mobileCols={2}>
-          <FormRow htmlFor="nombre" label="Nombre(s)" required>
-            <Input
-              {...register('nombre')}
-              id="nombre"
-              type="text"
-              placeholder="Ingrese nombre(s)"
-              hasError={errors?.nombre?.message}
-              variant="outline"
-              size="lg"
-            />
-          </FormRow>
-          <FormRow htmlFor="apellidos" label="Apellidos" required>
-            <Input
-              {...register('apellidos')}
-              id="apellidos"
-              type="text"
-              placeholder="Ingrese apellidos"
-              hasError={errors?.apellidos?.message}
-              variant="outline"
-              size="lg"
-            />
-          </FormRow>
-        </Grid>
+        {!syncMode && (
+          <Grid cols={2} gap={4} mobileCols={2}>
+            <FormRow htmlFor="nombre" label="Nombre(s)" required>
+              <Input
+                {...register('nombre')}
+                id="nombre"
+                type="text"
+                placeholder="Ingrese nombre(s)"
+                hasError={errors?.nombre?.message}
+                variant="outline"
+                size="lg"
+              />
+            </FormRow>
+            <FormRow htmlFor="apellidos" label="Apellidos" required>
+              <Input
+                {...register('apellidos')}
+                id="apellidos"
+                type="text"
+                placeholder="Ingrese apellidos"
+                hasError={errors?.apellidos?.message}
+                variant="outline"
+                size="lg"
+              />
+            </FormRow>
+          </Grid>
+        )}
 
-        <Grid cols={3} gap={4} mobileCols={2}>
-          <BirthdayField name="fecha_nacimiento" control={control} errors={errors} />
-          <PhoneField />
-          <FormRow label="Género" required error={errors?.genero?.message}>
-            <Controller
-              name="genero"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} fullWidth>
-                  <SelectTrigger size="lg" hasError={errors?.genero?.message}>
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Masculino">Masculino</SelectItem>
-                    <SelectItem value="Femenino">Femenino</SelectItem>
-                    <SelectItem value="Otro">Otro</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          </FormRow>
-        </Grid>
+        {!syncMode && (
+          <Grid cols={3} gap={4} mobileCols={2}>
+            <BirthdayField name="fecha_nacimiento" control={control} errors={errors} />
+            <PhoneField />
+            <FormRow label="Género" required error={errors?.genero?.message}>
+              <Controller
+                name="genero"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} fullWidth>
+                    <SelectTrigger size="lg" hasError={errors?.genero?.message}>
+                      <SelectValue placeholder="Seleccionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Masculino">Masculino</SelectItem>
+                      <SelectItem value="Femenino">Femenino</SelectItem>
+                      <SelectItem value="Otro">Otro</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormRow>
+          </Grid>
+        )}
+
+        {!syncMode && <ExternoCheckbox />}
 
         <FormRow htmlFor="motivo_consulta" label="Motivo de consulta">
           <Input
@@ -93,63 +102,65 @@ export default function IdentificacionNutrStep() {
       {/* ══ 2 · Información Adicional ══ */}
       <div className="space-y-4">
         <Heading as="h3" showBar>
-          Información Adicional
+          {syncMode ? 'Datos complementarios de nutrición' : 'Información Adicional'}
         </Heading>
 
-        <Grid cols={3} gap={4} mobileCols={2}>
-          <FormRow label="Ocupación">
-            <Controller
-              name="ocupacion"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} fullWidth>
-                  <SelectTrigger size="lg">
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {OCUPACION_NUTR_OPTIONS.map((op) => (
-                      <SelectItem key={op} value={op}>
-                        {op}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          </FormRow>
-          <FormRow label="Estado Civil">
-            <Controller
-              name="estado_civil"
-              control={control}
-              render={({ field }) => (
-                <Select value={field.value} onValueChange={field.onChange} fullWidth>
-                  <SelectTrigger size="lg">
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ESTADO_CIVIL_NUTR_OPTIONS.map((op) => (
-                      <SelectItem key={op} value={op}>
-                        {op}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          </FormRow>
-          <FormRow htmlFor="correo" label="Correo Electrónico">
-            <Input
-              {...register('correo')}
-              id="correo"
-              type="email"
-              placeholder="correo@ejemplo.com"
-              hasError={errors?.correo?.message}
-              variant="outline"
-              size="lg"
-              suffix={<HiOutlineEnvelope className="text-zinc-400" />}
-            />
-          </FormRow>
-        </Grid>
+        {!syncMode && (
+          <Grid cols={3} gap={4} mobileCols={2}>
+            <FormRow label="Ocupación">
+              <Controller
+                name="ocupacion"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} fullWidth>
+                    <SelectTrigger size="lg">
+                      <SelectValue placeholder="Seleccionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OCUPACION_NUTR_OPTIONS.map((op) => (
+                        <SelectItem key={op} value={op}>
+                          {op}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormRow>
+            <FormRow label="Estado Civil">
+              <Controller
+                name="estado_civil"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} fullWidth>
+                    <SelectTrigger size="lg">
+                      <SelectValue placeholder="Seleccionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ESTADO_CIVIL_NUTR_OPTIONS.map((op) => (
+                        <SelectItem key={op} value={op}>
+                          {op}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </FormRow>
+            <FormRow htmlFor="correo" label="Correo Electrónico">
+              <Input
+                {...register('correo')}
+                id="correo"
+                type="email"
+                placeholder="correo@ejemplo.com"
+                hasError={errors?.correo?.message}
+                variant="outline"
+                size="lg"
+                suffix={<HiOutlineEnvelope className="text-zinc-400" />}
+              />
+            </FormRow>
+          </Grid>
+        )}
 
         <Grid cols={3} gap={4} mobileCols={2}>
           <FormRow label="Escolaridad">

--- a/frontend/src/features/patients/nutricion/hooks/useCreatePatientWithNutritionHistory.js
+++ b/frontend/src/features/patients/nutricion/hooks/useCreatePatientWithNutritionHistory.js
@@ -8,14 +8,19 @@ export function useCreatePatientWithNutritionHistory() {
 
   const { mutateAsync, isPending } = useMutation({
     // Registro atómico server-side: el backend crea paciente + historia en una
-    // sola transacción, así que no hay rollback ni paciente huérfano que manejar.
-    mutationFn: ({ patientData, historyData }) =>
-      registerNutritionPatient({ patient: patientData, historia: historyData }),
-    onSuccess: () => {
+    // sola transacción. Con `pacienteId` sincroniza un paciente existente de
+    // otra área en vez de crear uno nuevo.
+    mutationFn: ({ patientData, historyData, pacienteId }) =>
+      registerNutritionPatient(
+        pacienteId
+          ? { paciente_id: pacienteId, patient: patientData, historia: historyData }
+          : { patient: patientData, historia: historyData }
+      ),
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['patients'] })
       queryClient.invalidateQueries({ queryKey: ['nutrition-histories'] })
       queryClient.invalidateQueries({ queryKey: ['stats'] })
-      toast.success('Paciente registrado correctamente')
+      toast.success(data?.message ?? 'Paciente registrado correctamente')
     },
   })
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -16,6 +16,9 @@ export function cn(...inputs) {
 
 export const isValidEmail = (email) => /^[\w.-]+@([\w-]+\.)+[a-zA-Z]{2,}$/.test(email)
 
+export const getInitials = (nombre, apellidos) =>
+  `${nombre?.[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase()
+
 /**
  * Omite recursivamente keys con valor vacío ('', null, undefined).
  * Si un objeto anidado queda sin keys, también se omite.

--- a/frontend/src/schemas/medicalPatient.js
+++ b/frontend/src/schemas/medicalPatient.js
@@ -2,10 +2,21 @@ import { z } from 'zod'
 import { patientSchema } from '@cais/shared/schemas/medicina/patient'
 import { medicalHistorySchema } from '@cais/shared/schemas/medicina/medicalHistory'
 import { dayjsDateSchema } from '@cais/shared/schemas/fields'
+import { syncPatientShape } from '@schemas/syncPatient'
 
 export const medicalPatientFormSchema = z.object({
   ...patientSchema.shape,
   ...medicalHistorySchema.omit({ paciente_id: true }).shape,
   fecha_nacimiento: dayjsDateSchema,
+  creado_at: dayjsDateSchema,
+})
+
+// Sincronización con un paciente existente de otra área: los compartidos van
+// ocultos (opcionales, tolerantes a vacío); se conserva la validación de los
+// complementarios que sí se capturan.
+export const medicalSyncFormSchema = z.object({
+  ...syncPatientShape,
+  ...medicalHistorySchema.omit({ paciente_id: true }).shape,
+  fecha_nacimiento: dayjsDateSchema.optional(),
   creado_at: dayjsDateSchema,
 })

--- a/frontend/src/schemas/medicalPatient.js
+++ b/frontend/src/schemas/medicalPatient.js
@@ -17,6 +17,5 @@ export const medicalPatientFormSchema = z.object({
 export const medicalSyncFormSchema = z.object({
   ...syncPatientShape,
   ...medicalHistorySchema.omit({ paciente_id: true }).shape,
-  fecha_nacimiento: dayjsDateSchema.optional(),
   creado_at: dayjsDateSchema,
 })

--- a/frontend/src/schemas/nutritionalPatient.js
+++ b/frontend/src/schemas/nutritionalPatient.js
@@ -8,6 +8,7 @@ import {
   evalActFisicaNutricionSchema,
 } from '@cais/shared/schemas/nutricion/nutritionHistory'
 import { dayjsDateSchema } from '@cais/shared/schemas/fields'
+import { syncPatientShape } from '@schemas/syncPatient'
 
 // _deleted: flag solo-UI del borrado-con-restauración de filas. Se declara aquí
 // porque el resolver de zod descarta las keys no presentes en el schema; sin
@@ -27,4 +28,16 @@ export const nutritionalPatientFormSchema = z.object({
   eval_cal_sueno: z.array(monitoringRow(evalCalSuenoSchema)).optional(),
   eval_act_fisica_nutricion: z.array(monitoringRow(evalActFisicaNutricionSchema)).optional(),
   fecha_nacimiento: dayjsDateSchema,
+})
+
+// Sincronización con un paciente existente de otra área: los compartidos van
+// ocultos (opcionales, tolerantes a vacío); se conserva la validación de los
+// complementarios que sí se capturan.
+export const nutritionalSyncFormSchema = z.object({
+  ...syncPatientShape,
+  ...nutritionHistorySchema.omit({ paciente_id: true }).shape,
+  historias_medicas_nutricion: z.array(deletableRow(historiasMedicasNutricionSchema)).optional(),
+  tratamiento_alt_nutricion: z.array(deletableRow(tratamientoAltNutricionSchema)).optional(),
+  eval_cal_sueno: z.array(monitoringRow(evalCalSuenoSchema)).optional(),
+  eval_act_fisica_nutricion: z.array(monitoringRow(evalActFisicaNutricionSchema)).optional(),
 })

--- a/frontend/src/schemas/syncPatient.js
+++ b/frontend/src/schemas/syncPatient.js
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { patientSchema } from '@cais/shared/schemas/medicina/patient'
+
+// Shape del paciente para el modo sincronización: cada campo queda opcional y
+// tolera '' (los compartidos van ocultos y vacíos, no deben bloquear), pero se
+// conserva la validación real (correo, enums, etc.) de los complementarios que
+// el usuario sí llena. El backend revalida con patientSchema.partial().
+export const syncPatientShape = Object.fromEntries(
+  Object.entries(patientSchema.shape).map(([key, schema]) => [
+    key,
+    z.preprocess((v) => (v === '' ? undefined : v), schema.optional()),
+  ])
+)

--- a/frontend/src/services/apiPatient.js
+++ b/frontend/src/services/apiPatient.js
@@ -21,6 +21,13 @@ export async function getPatient(id) {
   return fetchApi(`/pacientes/${id}`, { errorMsg: 'Error al obtener paciente' })
 }
 
+export async function getSimilarPatients({ nombre, apellidos, fecha_nacimiento, genero }) {
+  const params = new URLSearchParams({ nombre, apellidos, fecha_nacimiento, genero })
+  return fetchApi(`/pacientes/similares?${params}`, {
+    errorMsg: 'Error al buscar pacientes similares',
+  })
+}
+
 export async function createPatient(data) {
   return fetchApi('/pacientes', {
     method: 'POST',

--- a/shared/constants/patients.js
+++ b/shared/constants/patients.js
@@ -1,3 +1,10 @@
+// Búsqueda de pacientes similares en la otra área (sincronización).
+export const SIMILAR_PATIENT_THRESHOLD = 0.75
+export const SIMILAR_PATIENT_MIN_CHARS = 2
+// Cota superior de candidatos que el backend evalúa/devuelve (el ancla ya filtra
+// fuerte; esto acota el escaneo difuso ante fechas+género muy comunes).
+export const SIMILAR_PATIENT_LIMIT = 25
+
 export const PATIENT_SORT_KEYS = {
   NOMBRE_ASC: 'nombre-asc',
   NOMBRE_DESC: 'nombre-desc',

--- a/shared/constants/users.js
+++ b/shared/constants/users.js
@@ -9,6 +9,12 @@ export const AREAS = {
   NUTRICION: 'NUTRICION',
 }
 
+// Etiquetas legibles por área para la UI (chips, badges).
+export const AREA_LABELS = {
+  [AREAS.MEDICINA]: 'Medicina',
+  [AREAS.NUTRICION]: 'Nutrición',
+}
+
 export const ESTADOS = {
   ACTIVO: 'ACTIVO',
   INACTIVO: 'INACTIVO',

--- a/shared/schemas/medicina/patientRegistration.js
+++ b/shared/schemas/medicina/patientRegistration.js
@@ -1,14 +1,8 @@
-import { z } from 'zod'
+import { makeRegistrationSchema } from '../patientRegistration.js'
 import { patientSchema } from './patient.js'
 import { medicalHistorySchema } from './medicalHistory.js'
 
-// Registro atómico: paciente + su primera historia médica en un solo body.
-// La historia va sin paciente_id (se inyecta en el servidor tras crear el paciente).
-export const medicalRegistrationSchema = z.object({
-  patient: patientSchema,
-  historia: medicalHistorySchema.omit({ paciente_id: true }),
-})
-
-export function validateMedicalRegistration(input) {
-  return medicalRegistrationSchema.safeParse(input)
-}
+export const validateMedicalRegistration = makeRegistrationSchema(
+  patientSchema,
+  medicalHistorySchema
+)

--- a/shared/schemas/nutricion/patientRegistration.js
+++ b/shared/schemas/nutricion/patientRegistration.js
@@ -1,14 +1,8 @@
-import { z } from 'zod'
+import { makeRegistrationSchema } from '../patientRegistration.js'
 import { patientSchema } from '../medicina/patient.js'
 import { nutritionHistorySchema } from './nutritionHistory.js'
 
-// Registro atómico: paciente + su primera historia nutricional en un solo body.
-// La historia va sin paciente_id (se inyecta en el servidor tras crear el paciente).
-export const nutritionRegistrationSchema = z.object({
-  patient: patientSchema,
-  historia: nutritionHistorySchema.omit({ paciente_id: true }),
-})
-
-export function validateNutritionRegistration(input) {
-  return nutritionRegistrationSchema.safeParse(input)
-}
+export const validateNutritionRegistration = makeRegistrationSchema(
+  patientSchema,
+  nutritionHistorySchema
+)

--- a/shared/schemas/patientRegistration.js
+++ b/shared/schemas/patientRegistration.js
@@ -13,6 +13,9 @@ export function makeRegistrationSchema(patientSchema, historiaSchema) {
     patient: patientSchema.partial().optional(),
     historia,
   })
+  // Discrimina por presencia de la clave (no por truthiness): así un
+  // `paciente_id: ''` cae en syncSchema y uuidSchema lo rechaza, en vez de
+  // colarse a createSchema y crear un paciente nuevo.
   return (input) =>
-    input?.paciente_id ? syncSchema.safeParse(input) : createSchema.safeParse(input)
+    input && 'paciente_id' in input ? syncSchema.safeParse(input) : createSchema.safeParse(input)
 }

--- a/shared/schemas/patientRegistration.js
+++ b/shared/schemas/patientRegistration.js
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import { uuidSchema } from './fields.js'
+
+// Registro atómico ({ patient }) o sincronización a un paciente existente de la
+// otra área ({ paciente_id }). Al sincronizar, `patient` es opcional y parcial:
+// lleva solo los datos complementarios que la otra área no captura (el backend
+// nunca sobrescribe campos ya capturados).
+export function makeRegistrationSchema(patientSchema, historiaSchema) {
+  const historia = historiaSchema.omit({ paciente_id: true })
+  const createSchema = z.object({ patient: patientSchema, historia })
+  const syncSchema = z.object({
+    paciente_id: uuidSchema,
+    patient: patientSchema.partial().optional(),
+    historia,
+  })
+  return (input) =>
+    input?.paciente_id ? syncSchema.safeParse(input) : createSchema.safeParse(input)
+}

--- a/shared/schemas/similarPatients.js
+++ b/shared/schemas/similarPatients.js
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+import { dateSchema } from './fields.js'
+import { SIMILAR_PATIENT_MIN_CHARS } from '../constants/patients.js'
+
+export const similarPatientsQuerySchema = z.object({
+  nombre: z.string({ error: 'Debe ser texto' }).trim().min(SIMILAR_PATIENT_MIN_CHARS),
+  apellidos: z.string({ error: 'Debe ser texto' }).trim().min(SIMILAR_PATIENT_MIN_CHARS),
+  fecha_nacimiento: dateSchema,
+  genero: z.string({ error: 'Debe ser texto' }).min(1),
+})
+
+export function validateSimilarPatientsQuery(input) {
+  return similarPatientsQuerySchema.safeParse(input)
+}


### PR DESCRIPTION
Un paciente puede pertenecer a medicina y nutrición sin duplicarse. Al registrar en un área se consultan pacientes similares en la otra (ancla fecha+género + similitud difusa de nombre) y, si el usuario confirma, se agrega la nueva área al expediente existente en vez de crear uno nuevo.

- tabla pacientes_areas (membresía por área) + migración con backfill
- endpoint GET /pacientes/similares (identidad mínima, acotado, sin huérfanos)
- registro acepta { paciente_id, patient?, historia } para sincronizar
- fill-missing: solo rellena campos vacíos, no sobreescribe la otra área
- acceso/borrado/stats por membresía; es_externo capturado por ambas áreas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added patient-area membership management, including syncing patients across care areas.
  * Added “similar patients” search with a new `/pacientes/similares` endpoint, debounced suggestions, and fuzzy name matching.
  * Introduced UI banners and sync-mode forms for registering history on existing patients, plus support for marking “external” patients.
* **Bug Fixes**
  * Improved area-scoped access control for patient data.
  * Added safeguards to prevent accidental deletion when a patient belongs to multiple areas (non-admins).
  * Added request query validation for similar-patient lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->