### PR TITLE
feat(estadisticas): exportación de reportes en Excel y PDF

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "11.14.1",
     "@hookform/resolvers": "5.2.2",
     "@mui/x-date-pickers": "8.27.2",
+    "@react-pdf/renderer": "4.5.1",
     "@tailwindcss/vite": "4.1.16",
     "@tanstack/react-query": "5.90.5",
     "@tanstack/react-query-devtools": "5.90.2",
@@ -23,6 +24,7 @@
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
     "dayjs": "1.11.19",
+    "file-saver": "2.0.5",
     "json-server": "1.0.0-beta.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -34,6 +36,8 @@
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.1.16",
+    "tslib": "2.8.1",
+    "write-excel-file": "4.1.1",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/frontend/src/features/dashboard/components/DistributionPieChart.jsx
+++ b/frontend/src/features/dashboard/components/DistributionPieChart.jsx
@@ -1,20 +1,5 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
-
-const GENDER_ITEMS = [
-  { key: 'Masculino', label: 'Hombres', color: '#3b82f6' }, // Blue-500
-  { key: 'Femenino', label: 'Mujeres', color: '#ec4899' }, // Pink-500
-]
-
-const AGE_ITEMS = [
-  { key: '< 18', label: '< 18 años', color: '#14b8a6' }, // Emerald-500
-  { key: '18 - 59', label: '18 - 59 años', color: '#0ea5e9' }, // Teal-500
-  { key: '>= 60', label: '>= 60 años', color: '#f59e0b' }, // Amber-500
-]
-
-const PROCEDENCIA_ITEMS = [
-  { key: 'interno', label: 'Internos (UABC)', color: '#6366f1' }, // Indigo-500
-  { key: 'externo', label: 'Externos', color: '#f97316' }, // Orange-500
-]
+import { GENDER_ITEMS, AGE_ITEMS, PROCEDENCIA_ITEMS } from '@features/dashboard/distributionConfig'
 
 function LegendItem({ color, label, count }) {
   return (

--- a/frontend/src/features/dashboard/distributionConfig.js
+++ b/frontend/src/features/dashboard/distributionConfig.js
@@ -1,0 +1,23 @@
+// Catálogos de las distribuciones de pacientes (género, edad, procedencia).
+// Fuente única para las gráficas del dashboard y los reportes de exportación,
+// así la etiqueta en pantalla y en el PDF/Excel nunca se desincronizan.
+export const GENDER_ITEMS = [
+  { key: 'Masculino', label: 'Hombres', color: '#3b82f6' }, // Blue-500
+  { key: 'Femenino', label: 'Mujeres', color: '#ec4899' }, // Pink-500
+]
+
+export const AGE_ITEMS = [
+  { key: '< 18', label: '< 18 años', color: '#14b8a6' }, // Emerald-500
+  { key: '18 - 59', label: '18 - 59 años', color: '#0ea5e9' }, // Teal-500
+  { key: '>= 60', label: '>= 60 años', color: '#f59e0b' }, // Amber-500
+]
+
+export const PROCEDENCIA_ITEMS = [
+  { key: 'interno', label: 'Internos (UABC)', color: '#6366f1' }, // Indigo-500
+  { key: 'externo', label: 'Externos', color: '#f97316' }, // Orange-500
+]
+
+const toLabels = (items) => Object.fromEntries(items.map((i) => [i.key, i.label]))
+export const GENDER_LABELS = toLabels(GENDER_ITEMS)
+export const AGE_LABELS = toLabels(AGE_ITEMS)
+export const PROCEDENCIA_LABELS = toLabels(PROCEDENCIA_ITEMS)

--- a/frontend/src/features/estadisticas/export/ExportModal.jsx
+++ b/frontend/src/features/estadisticas/export/ExportModal.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { pdf } from '@react-pdf/renderer'
+import { saveAs } from 'file-saver'
+import { toast } from 'sonner'
+import { HiCheck, HiOutlineTableCells, HiOutlineDocumentText } from 'react-icons/hi2'
+import { cn } from '@lib/utils'
+import Button from '@components/Button'
+import { buildStatsExport, exportFileName } from '@features/estadisticas/export/buildStatsExport'
+import { exportStatsExcel } from '@features/estadisticas/export/exportStatsExcel'
+import StatsPdfDocument from '@features/estadisticas/export/StatsPdfDocument'
+
+const FORMATS = [
+  { key: 'excel', label: 'Excel', hint: 'Formato .xlsx', ext: 'xlsx', icon: HiOutlineTableCells },
+  { key: 'pdf', label: 'PDF', hint: 'Formato .pdf', ext: 'pdf', icon: HiOutlineDocumentText },
+]
+
+function FormatCard({ format, selected, onSelect }) {
+  const Icon = format.icon
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'relative flex flex-1 flex-col items-center gap-2 rounded-xl border p-5 transition-colors',
+        selected ? 'border-green-800 bg-green-50' : 'border-gray-200 bg-white hover:border-gray-300'
+      )}
+    >
+      {selected && (
+        <span className="absolute top-3 right-3 grid size-5 place-items-center rounded-full bg-green-800 text-white">
+          <HiCheck size={12} strokeWidth={3} />
+        </span>
+      )}
+      <span
+        className={cn(
+          'grid size-12 place-items-center rounded-xl',
+          selected ? 'bg-green-800 text-white' : 'bg-gray-100 text-gray-500'
+        )}
+      >
+        <Icon size={24} />
+      </span>
+      <span className="text-5 font-medium text-gray-800">{format.label}</span>
+      <span className="text-6 text-gray-500">{format.hint}</span>
+    </button>
+  )
+}
+
+export default function ExportModal({ context, onCloseModal }) {
+  const [selected, setSelected] = useState('excel')
+  const [isExporting, setIsExporting] = useState(false)
+  const format = FORMATS.find((f) => f.key === selected)
+
+  async function handleExport() {
+    if (!context.stats?.counts) {
+      toast.error('No hay datos para exportar todavía')
+      return
+    }
+    setIsExporting(true)
+    try {
+      const model = buildStatsExport(context.stats, context.meta)
+      const fileName = exportFileName(context.meta.area, format.ext)
+      if (format.key === 'excel') {
+        await exportStatsExcel(model, fileName)
+      } else {
+        const blob = await pdf(<StatsPdfDocument model={model} />).toBlob()
+        saveAs(blob, fileName)
+      }
+      toast.success('Estadísticas exportadas correctamente')
+      onCloseModal?.()
+    } catch (err) {
+      console.error('Error al exportar estadísticas:', err)
+      toast.error('No se pudieron exportar las estadísticas')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <div className="flex w-[440px] flex-col gap-5 max-sm:w-full">
+      <div>
+        <h3 className="text-3 font-medium text-gray-800">Exportar Estadísticas</h3>
+        <p className="text-6 mt-1 text-gray-500">Selecciona el formato para exportar</p>
+      </div>
+
+      <div>
+        <p className="text-6 mb-2 font-medium text-gray-600">Formato de Exportación</p>
+        <div className="flex gap-3">
+          {FORMATS.map((f) => (
+            <FormatCard
+              key={f.key}
+              format={f}
+              selected={selected === f.key}
+              onSelect={() => setSelected(f.key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-3 border-t border-gray-100 pt-4">
+        <Button variant="outline" size="md" onClick={onCloseModal} disabled={isExporting}>
+          Cancelar
+        </Button>
+        <Button variant="primary" size="md" onClick={handleExport} isLoading={isExporting}>
+          Exportar {format.label}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/estadisticas/export/StatsPdfDocument.jsx
+++ b/frontend/src/features/estadisticas/export/StatsPdfDocument.jsx
@@ -1,0 +1,137 @@
+import { Document, Page, View, Text, StyleSheet } from '@react-pdf/renderer'
+import { REPORT_COLORS as C } from '@features/estadisticas/export/reportTheme'
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 40,
+    paddingBottom: 48,
+    paddingHorizontal: 44,
+    fontSize: 10,
+    color: C.text,
+  },
+  header: { borderBottomWidth: 2, borderBottomColor: C.ink, paddingBottom: 10, marginBottom: 16 },
+  title: { fontSize: 17, fontWeight: 'bold', color: C.ink, letterSpacing: 0.3 },
+  subtitle: { fontSize: 9.5, color: C.muted, marginTop: 3 },
+  metaGrid: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 22 },
+  metaItem: { width: '50%', marginBottom: 5, flexDirection: 'row' },
+  metaLabel: { color: C.muted, width: 78, fontSize: 9 },
+  metaValue: { color: C.ink, fontSize: 9, fontWeight: 'bold' },
+
+  section: { marginBottom: 16 },
+  sectionBar: {
+    backgroundColor: C.band,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: { fontSize: 10.5, fontWeight: 'bold', color: C.white, letterSpacing: 0.4 },
+  sectionMeta: { fontSize: 8.5, color: C.borderStrong },
+
+  table: { borderWidth: 1, borderColor: C.border, borderTopWidth: 0 },
+  headerRow: {
+    flexDirection: 'row',
+    backgroundColor: C.subtle,
+    borderBottomWidth: 1,
+    borderBottomColor: C.borderStrong,
+  },
+  row: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: C.border },
+  lastRow: { flexDirection: 'row' },
+  zebra: { backgroundColor: C.zebra },
+  cell: { paddingVertical: 5, paddingHorizontal: 10, fontSize: 9.5 },
+  headerCell: { color: C.ink, fontWeight: 'bold', fontSize: 9 },
+
+  footer: {
+    position: 'absolute',
+    bottom: 26,
+    left: 44,
+    right: 44,
+    borderTopWidth: 1,
+    borderTopColor: C.border,
+    paddingTop: 6,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    fontSize: 8,
+    color: C.muted,
+  },
+})
+
+// Primera columna flexible; las de datos, fijas y alineadas a la derecha.
+function colStyle(index, total) {
+  if (index === 0) return { flex: 1 }
+  return { width: 78, textAlign: total > 2 ? 'right' : 'left' }
+}
+
+function Table({ columns, rows }) {
+  return (
+    <View style={styles.table}>
+      <View style={styles.headerRow}>
+        {columns.map((col, i) => (
+          <Text key={col} style={[styles.cell, styles.headerCell, colStyle(i, columns.length)]}>
+            {col}
+          </Text>
+        ))}
+      </View>
+      {rows.length === 0 ? (
+        <View style={styles.lastRow}>
+          <Text style={[styles.cell, { color: C.muted }]}>Sin datos</Text>
+        </View>
+      ) : (
+        rows.map((row, r) => (
+          <View
+            key={r}
+            style={[
+              r === rows.length - 1 ? styles.lastRow : styles.row,
+              r % 2 === 1 && styles.zebra,
+            ]}
+          >
+            {row.map((val, c) => (
+              <Text key={c} style={[styles.cell, colStyle(c, columns.length)]}>
+                {String(val)}
+              </Text>
+            ))}
+          </View>
+        ))
+      )}
+    </View>
+  )
+}
+
+export default function StatsPdfDocument({ model }) {
+  return (
+    <Document title={model.title}>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{model.title}</Text>
+          <Text style={styles.subtitle}>Centro de Atención Integral para la Salud — UABC</Text>
+        </View>
+
+        <View style={styles.metaGrid}>
+          {model.meta.map(([label, value]) => (
+            <View key={label} style={styles.metaItem}>
+              <Text style={styles.metaLabel}>{label}</Text>
+              <Text style={styles.metaValue}>{value}</Text>
+            </View>
+          ))}
+        </View>
+
+        {model.sections.map((section) => (
+          <View key={section.title} style={styles.section} wrap={false}>
+            <View style={styles.sectionBar}>
+              <Text style={styles.sectionTitle}>{section.title.toUpperCase()}</Text>
+              {section.total != null && (
+                <Text style={styles.sectionMeta}>Total: {section.total}</Text>
+              )}
+            </View>
+            <Table columns={section.columns} rows={section.rows} />
+          </View>
+        ))}
+
+        <View style={styles.footer} fixed>
+          <Text>Centro de Atención Integral para la Salud — UABC</Text>
+          <Text render={({ pageNumber, totalPages }) => `Página ${pageNumber} de ${totalPages}`} />
+        </View>
+      </Page>
+    </Document>
+  )
+}

--- a/frontend/src/features/estadisticas/export/StatsPdfDocument.jsx
+++ b/frontend/src/features/estadisticas/export/StatsPdfDocument.jsx
@@ -57,9 +57,9 @@ const styles = StyleSheet.create({
 })
 
 // Primera columna flexible; las de datos, fijas y alineadas a la derecha.
-function colStyle(index, total) {
+function colStyle(index) {
   if (index === 0) return { flex: 1 }
-  return { width: 78, textAlign: total > 2 ? 'right' : 'left' }
+  return { width: 78, textAlign: 'right' }
 }
 
 function Table({ columns, rows }) {
@@ -67,7 +67,7 @@ function Table({ columns, rows }) {
     <View style={styles.table}>
       <View style={styles.headerRow}>
         {columns.map((col, i) => (
-          <Text key={col} style={[styles.cell, styles.headerCell, colStyle(i, columns.length)]}>
+          <Text key={col} style={[styles.cell, styles.headerCell, colStyle(i)]}>
             {col}
           </Text>
         ))}
@@ -86,7 +86,7 @@ function Table({ columns, rows }) {
             ]}
           >
             {row.map((val, c) => (
-              <Text key={c} style={[styles.cell, colStyle(c, columns.length)]}>
+              <Text key={c} style={[styles.cell, colStyle(c)]}>
                 {String(val)}
               </Text>
             ))}

--- a/frontend/src/features/estadisticas/export/buildStatsExport.js
+++ b/frontend/src/features/estadisticas/export/buildStatsExport.js
@@ -1,0 +1,89 @@
+import dayjs from 'dayjs'
+import { AREA_LABELS } from '@cais/shared/constants/users'
+import {
+  GENDER_LABELS,
+  AGE_LABELS,
+  PROCEDENCIA_LABELS,
+} from '@features/dashboard/distributionConfig'
+
+// Etiquetas de los counts (mismas que las cards del dashboard). `usuarios_conectados`
+// se omite a propósito: es un dato en vivo, no tiene sentido en un reporte.
+const COUNT_LABELS = {
+  pacientes: 'Pacientes registrados',
+  notas_evolucion: 'Notas de evolución',
+  historias_medicas: 'Historias médicas',
+  emergencias: 'Emergencias',
+  historias_nutricion: 'Historias de nutrición',
+  eval_antropometricas: 'Evaluaciones antropométricas',
+  eval_nutricionales: 'Evaluaciones nutricionales',
+}
+const COUNT_ORDER = Object.keys(COUNT_LABELS)
+
+const pct = (count, total) => (total > 0 ? `${Math.round((count / total) * 100)}%` : '0%')
+
+// Convierte una distribución [{ [keyField]: k, count }] en una sección con filas
+// [label, total, %]. Las etiquetas vienen del catálogo compartido con las gráficas.
+function distributionSection(title, items, keyField, labelMap) {
+  const parsed = (items ?? []).map((it) => ({
+    label: labelMap[it[keyField]] ?? it[keyField],
+    count: Number(it.count) || 0,
+  }))
+  const total = parsed.reduce((sum, r) => sum + r.count, 0)
+  return {
+    title,
+    columns: ['Categoría', 'Total', '%'],
+    rows: parsed.map((r) => [r.label, r.count, pct(r.count, total)]),
+    total,
+  }
+}
+
+export function areaLabelFor(area) {
+  return area ? (AREA_LABELS[area] ?? area) : 'Todas'
+}
+
+/**
+ * Modelo neutral de exportación: fuente única que consumen el generador de PDF
+ * y el de Excel. Toma el `stats` de la página y el contexto del reporte.
+ */
+export function buildStatsExport(stats, { area, rangeLabel, rangeCaption, generatedBy }) {
+  const counts = stats?.counts ?? {}
+  const resumenRows = COUNT_ORDER.filter((key) => counts[key] != null).map((key) => [
+    COUNT_LABELS[key],
+    counts[key],
+  ])
+
+  return {
+    title: 'Reporte de Estadísticas',
+    meta: [
+      ['Área', areaLabelFor(area)],
+      ['Periodo', `${rangeLabel} (${rangeCaption})`],
+      ['Generado', dayjs().format('DD/MM/YYYY HH:mm')],
+      ['Generado por', generatedBy ?? '—'],
+    ],
+    sections: [
+      { title: 'Resumen', columns: ['Métrica', 'Total'], rows: resumenRows },
+      distributionSection(
+        'Procedencia',
+        stats?.distribucion_procedencia,
+        'procedencia',
+        PROCEDENCIA_LABELS
+      ),
+      distributionSection(
+        'Distribución por género',
+        stats?.distribucion_genero,
+        'genero',
+        GENDER_LABELS
+      ),
+      distributionSection('Distribución por edad', stats?.distribucion_edad, 'rango', AGE_LABELS),
+    ],
+  }
+}
+
+export function exportFileName(area, ext) {
+  const slug = areaLabelFor(area)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '-')
+  return `estadisticas-${slug}-${dayjs().format('YYYY-MM-DD')}.${ext}`
+}

--- a/frontend/src/features/estadisticas/export/exportStatsExcel.js
+++ b/frontend/src/features/estadisticas/export/exportStatsExcel.js
@@ -1,0 +1,87 @@
+import writeXlsxFile from 'write-excel-file/browser'
+import { REPORT_COLORS } from '@features/estadisticas/export/reportTheme'
+
+const { ink: INK, band: BAND, subtle: SUBTLE, borderStrong: BORDER } = REPORT_COLORS
+const { muted: MUTED, text: TEXT, zebra: ZEBRA, white: WHITE } = REPORT_COLORS
+
+const NCOLS = 3
+const COLUMNS = [{ width: 40 }, { width: 16 }, { width: 12 }]
+
+const base = (value, extra = {}) =>
+  value == null ? null : { value, type: typeof value === 'number' ? Number : String, ...extra }
+
+const titleRow = (text) => [
+  base(text, { fontSize: 16, fontWeight: 'bold', textColor: INK, columnSpan: NCOLS, height: 24 }),
+]
+const subtitleRow = (text) => [base(text, { textColor: MUTED, columnSpan: NCOLS })]
+
+const metaRow = (label, value) => [
+  base(label, { fontWeight: 'bold', textColor: MUTED }),
+  base(value, { textColor: INK, columnSpan: NCOLS - 1 }),
+]
+
+const sectionRow = (text) => [
+  base(text, {
+    fontWeight: 'bold',
+    textColor: WHITE,
+    backgroundColor: BAND,
+    columnSpan: NCOLS,
+    height: 20,
+    alignVertical: 'center',
+    indent: 1,
+  }),
+]
+
+const headerRow = (columns) =>
+  columns.map((col, i) =>
+    base(col, {
+      fontWeight: 'bold',
+      textColor: INK,
+      backgroundColor: SUBTLE,
+      align: i === 0 ? 'left' : 'right',
+      alignVertical: 'center',
+      height: 18,
+      bottomBorderColor: BORDER,
+      bottomBorderStyle: 'medium',
+      indent: i === 0 ? 1 : undefined,
+    })
+  )
+
+const dataRow = (cells, zebra) =>
+  cells.map((val, i) =>
+    base(val, {
+      textColor: TEXT,
+      align: i === 0 ? 'left' : 'right',
+      backgroundColor: zebra ? ZEBRA : WHITE,
+      bottomBorderColor: SUBTLE,
+      bottomBorderStyle: 'thin',
+      indent: i === 0 ? 1 : undefined,
+    })
+  )
+
+// Genera el .xlsx en el navegador y dispara la descarga vía `.toFile()`.
+// write-excel-file es browser-first, así que no tiene el problema de bundling
+// de ExcelJS en producción.
+export async function exportStatsExcel(model, fileName) {
+  const data = [
+    titleRow(model.title),
+    subtitleRow('Centro de Atención Integral para la Salud — UABC'),
+    [],
+  ]
+
+  for (const [label, value] of model.meta) data.push(metaRow(label, value))
+  data.push([])
+
+  for (const section of model.sections) {
+    data.push(sectionRow(section.title))
+    data.push(headerRow(section.columns))
+    if (section.rows.length === 0) {
+      data.push([base('Sin datos', { textColor: MUTED, indent: 1, columnSpan: NCOLS })])
+    } else {
+      section.rows.forEach((row, i) => data.push(dataRow(row, i % 2 === 1)))
+    }
+    data.push([])
+  }
+
+  await writeXlsxFile(data, { columns: COLUMNS }).toFile(fileName)
+}

--- a/frontend/src/features/estadisticas/export/reportTheme.js
+++ b/frontend/src/features/estadisticas/export/reportTheme.js
@@ -1,0 +1,13 @@
+// Paleta neutra/institucional (slate) compartida por el PDF y el Excel, para que
+// ambos reportes se vean idénticos y una re-tuneada de color viva en un solo lugar.
+export const REPORT_COLORS = {
+  ink: '#1E293B', // slate-800 — títulos
+  band: '#334155', // slate-700 — banda de sección
+  subtle: '#F1F5F9', // slate-100 — header de columnas
+  border: '#E2E8F0', // slate-200
+  borderStrong: '#CBD5E1', // slate-300
+  text: '#334155', // slate-700 — cuerpo
+  muted: '#64748B', // slate-500
+  zebra: '#F8FAFC', // slate-50
+  white: '#FFFFFF',
+}

--- a/frontend/src/pages/Estadisticas.jsx
+++ b/frontend/src/pages/Estadisticas.jsx
@@ -5,10 +5,13 @@ import {
   STATS_RANGE_CAPTIONS,
 } from '@cais/shared/constants/stats'
 import { useDashboardStats } from '@features/dashboard/hooks/useDashboardStats'
+import usePermissions from '@hooks/usePermissions'
 import StatCardsGrid from '@features/dashboard/components/StatCardsGrid'
 import RangeSelect from '@features/dashboard/components/RangeSelect'
 import ScopeBadge from '@features/dashboard/components/ScopeBadge'
+import ExportModal from '@features/estadisticas/export/ExportModal'
 import Button from '@ui/components/Button'
+import Modal from '@ui/components/Modal'
 import Heading from '@ui/components/Heading'
 import { HiOutlineArrowDownTray } from 'react-icons/hi2'
 
@@ -48,10 +51,21 @@ function DistributionPanel({ children }) {
 export default function Estadisticas() {
   const [range, setRange] = useState(DEFAULT_STATS_RANGE)
   const { stats, isPending } = useDashboardStats(range)
+  const { area, user } = usePermissions()
 
   const counts = stats?.counts
   const rangeLabel = STATS_RANGE_LABELS[range]
   const rangeCaption = STATS_RANGE_CAPTIONS[range]
+
+  const exportContext = {
+    stats,
+    meta: {
+      area,
+      rangeLabel,
+      rangeCaption,
+      generatedBy: user?.nombre ?? user?.correo ?? '—',
+    },
+  }
 
   return (
     <div className="space-y-6 p-6">
@@ -62,11 +76,17 @@ export default function Estadisticas() {
         </Heading>
         <div className="flex items-center gap-3">
           <RangeSelect value={range} onChange={setRange} />
-          {/* TODO: exportación de estadísticas pendiente (PR siguiente). */}
-          <Button variant="primary" size="md" disabled>
-            <HiOutlineArrowDownTray size={16} />
-            Exportar
-          </Button>
+          <Modal>
+            <Modal.Open opens="export-stats">
+              <Button variant="primary" size="md" disabled={isPending}>
+                <HiOutlineArrowDownTray size={16} />
+                Exportar
+              </Button>
+            </Modal.Open>
+            <Modal.Content name="export-stats" variant="alert">
+              <ExportModal context={exportContext} />
+            </Modal.Content>
+          </Modal>
         </div>
       </div>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,11 @@ const __dirname = path.dirname(__filename)
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // @react-pdf/renderer importa `tslib` como bare module que el optimizador de
+  // Vite no descubre solo; forzar su pre-bundle evita el fallo de resolución.
+  optimizeDeps: {
+    include: ['tslib'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@mui/x-date-pickers':
         specifier: 8.27.2
         version: 8.27.2(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(react@19.2.4))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(react@19.2.4))(@types/react@19.2.16)(date-fns@4.1.0)(dayjs@1.11.19)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@react-pdf/renderer':
+        specifier: 4.5.1
+        version: 4.5.1(react@19.2.4)
       '@tailwindcss/vite':
         specifier: 4.1.16
         version: 4.1.16(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -136,6 +139,9 @@ importers:
       dayjs:
         specifier: 1.11.19
         version: 1.11.19
+      file-saver:
+        specifier: 2.0.5
+        version: 2.0.5
       json-server:
         specifier: 1.0.0-beta.3
         version: 1.0.0-beta.3
@@ -169,6 +175,12 @@ importers:
       tailwindcss:
         specifier: 4.1.16
         version: 4.1.16
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+      write-excel-file:
+        specifier: 4.1.1
+        version: 4.1.1
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -851,6 +863,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -932,6 +948,49 @@ packages:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
+
+  '@react-pdf/fns@3.1.3':
+    resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
+
+  '@react-pdf/font@4.0.8':
+    resolution: {integrity: sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==}
+
+  '@react-pdf/image@3.1.0':
+    resolution: {integrity: sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==}
+
+  '@react-pdf/layout@4.6.1':
+    resolution: {integrity: sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==}
+
+  '@react-pdf/pdfkit@5.1.1':
+    resolution: {integrity: sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==}
+
+  '@react-pdf/primitives@4.3.0':
+    resolution: {integrity: sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==}
+
+  '@react-pdf/reconciler@2.0.0':
+    resolution: {integrity: sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/render@4.5.1':
+    resolution: {integrity: sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==}
+
+  '@react-pdf/renderer@4.5.1':
+    resolution: {integrity: sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/stylesheet@6.2.1':
+    resolution: {integrity: sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==}
+
+  '@react-pdf/svg@1.1.0':
+    resolution: {integrity: sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==}
+
+  '@react-pdf/textkit@6.3.0':
+    resolution: {integrity: sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==}
+
+  '@react-pdf/types@2.11.1':
+    resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
 
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
@@ -1059,6 +1118,9 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/node@4.1.16':
     resolution: {integrity: sha512-BX5iaSsloNuvKNHRN3k2RcCuTEgASTo77mofW0vmeHkfrDWaoFAFvNHpEgtu0eqyypcyiBkDWzSMxJhp3AUVcw==}
@@ -1543,6 +1605,9 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1691,6 +1756,13 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.34:
     resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
     engines: {node: '>=6.0.0'}
@@ -1716,6 +1788,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1818,6 +1896,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1835,6 +1917,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.1:
+    resolution: {integrity: sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -2067,6 +2157,9 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -2107,6 +2200,9 @@ packages:
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2294,6 +2390,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2355,9 +2455,15 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-saver@2.0.5:
+    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2384,6 +2490,9 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2563,6 +2672,12 @@ packages:
     resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
     engines: {node: '>=16.9.0'}
 
+  hsl-to-hex@1.0.0:
+    resolution: {integrity: sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==}
+
+  hsl-to-rgb-for-reals@1.1.1:
+    resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -2596,6 +2711,9 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2779,6 +2897,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -2823,6 +2944,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jay-peg@1.1.1:
+    resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
   jest-changed-files@30.2.0:
     resolution: {integrity: sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==}
@@ -2955,6 +3079,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3170,6 +3297,9 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -3253,6 +3383,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-engine@1.0.3:
+    resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -3387,6 +3520,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-svg-path@1.1.0:
+    resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -3480,6 +3616,12 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3487,6 +3629,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -3549,9 +3694,15 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  png-js@2.0.0:
+    resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -3669,6 +3820,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   random-bytes@1.0.0:
     resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
@@ -3838,6 +3992,9 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -3875,6 +4032,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.25.0-rc-603e6108-20241029:
+    resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4067,6 +4227,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4114,6 +4277,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-arc-to-cubic-bezier@3.2.0:
+    resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4134,6 +4300,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -4242,6 +4411,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -4263,6 +4438,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -4281,6 +4459,10 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
+  vite-compatible-readable-stream@3.6.1:
+    resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
+    engines: {node: '>= 6'}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -4447,6 +4629,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  write-excel-file@4.1.1:
+    resolution: {integrity: sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==}
+    engines: {node: '>=18'}
+
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4497,6 +4683,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
@@ -5296,6 +5485,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/hashes@1.8.0': {}
 
   '@oxc-project/types@0.133.0': {}
@@ -5396,6 +5587,110 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@react-pdf/fns@3.1.3': {}
+
+  '@react-pdf/font@4.0.8':
+    dependencies:
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/types': 2.11.1
+      fontkit: 2.0.4
+      is-url: 1.2.4
+
+  '@react-pdf/image@3.1.0':
+    dependencies:
+      '@react-pdf/svg': 1.1.0
+      jay-peg: 1.1.1
+      png-js: 2.0.0
+
+  '@react-pdf/layout@4.6.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/image': 3.1.0
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      emoji-regex-xs: 1.0.0
+      queue: 6.0.2
+      yoga-layout: 3.2.1
+
+  '@react-pdf/pdfkit@5.1.1':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      browserify-zlib: 0.2.0
+      fontkit: 2.0.4
+      jay-peg: 1.1.1
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 2.0.0
+      vite-compatible-readable-stream: 3.6.1
+
+  '@react-pdf/primitives@4.3.0': {}
+
+  '@react-pdf/reconciler@2.0.0(react@19.2.4)':
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.4
+      scheduler: 0.25.0-rc-603e6108-20241029
+
+  '@react-pdf/render@4.5.1':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      abs-svg-path: 0.1.1
+      color-string: 2.1.4
+      normalize-svg-path: 1.1.0
+      parse-svg-path: 0.1.2
+      svg-arc-to-cubic-bezier: 3.2.0
+
+  '@react-pdf/renderer@4.5.1(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/layout': 4.6.1
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/reconciler': 2.0.0(react@19.2.4)
+      '@react-pdf/render': 4.5.1
+      '@react-pdf/types': 2.11.1
+      events: 3.3.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      queue: 6.0.2
+      react: 19.2.4
+
+  '@react-pdf/stylesheet@6.2.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/types': 2.11.1
+      color-string: 2.1.4
+      hsl-to-hex: 1.0.0
+      media-engine: 1.0.3
+      postcss-value-parser: 4.2.0
+
+  '@react-pdf/svg@1.1.0':
+    dependencies:
+      '@react-pdf/primitives': 4.3.0
+
+  '@react-pdf/textkit@6.3.0':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      bidi-js: 1.0.3
+      hyphen: 1.14.1
+      unicode-properties: 1.4.1
+
+  '@react-pdf/types@2.11.1':
+    dependencies:
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.16)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5474,6 +5769,10 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.1.16':
     dependencies:
@@ -5912,6 +6211,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abs-svg-path@0.1.1: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -6100,6 +6401,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.34: {}
 
   bcryptjs@3.0.3: {}
@@ -6134,6 +6439,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.2:
     dependencies:
@@ -6244,6 +6557,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   co@4.6.0: {}
@@ -6255,6 +6570,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-name@2.1.1: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.1
 
   colorette@2.0.20: {}
 
@@ -6445,6 +6766,8 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
+  dfa@1.2.0: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -6482,6 +6805,8 @@ snapshots:
   electron-to-chromium@1.5.368: {}
 
   emittery@0.13.1: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6748,6 +7073,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events@3.3.0: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -6846,9 +7173,13 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-saver@2.0.5: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -6883,6 +7214,18 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -7069,6 +7412,12 @@ snapshots:
 
   hono@4.11.4: {}
 
+  hsl-to-hex@1.0.0:
+    dependencies:
+      hsl-to-rgb-for-reals: 1.1.1
+
+  hsl-to-rgb-for-reals@1.1.1: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -7104,6 +7453,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
+
+  hyphen@1.14.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -7271,6 +7622,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.22
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -7331,6 +7684,10 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jay-peg@1.1.1:
+    dependencies:
+      restructure: 3.0.2
 
   jest-changed-files@30.2.0:
     dependencies:
@@ -7645,6 +8002,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-md5@0.8.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -7829,6 +8188,11 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   lint-staged@17.0.7:
@@ -7921,6 +8285,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
+
+  media-engine@1.0.3: {}
 
   media-typer@1.1.0: {}
 
@@ -8017,6 +8383,10 @@ snapshots:
   nodemailer@8.0.10: {}
 
   normalize-path@3.0.0: {}
+
+  normalize-svg-path@1.1.0:
+    dependencies:
+      svg-arc-to-cubic-bezier: 3.2.0
 
   npm-run-path@4.0.1:
     dependencies:
@@ -8121,6 +8491,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8131,6 +8505,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-svg-path@0.1.2: {}
 
   parse5@8.0.1:
     dependencies:
@@ -8177,7 +8553,13 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  png-js@2.0.0:
+    dependencies:
+      fflate: 0.8.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.15:
     dependencies:
@@ -8247,6 +8629,10 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   random-bytes@1.0.0: {}
 
@@ -8417,6 +8803,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  restructure@3.0.2: {}
+
   retry@0.12.0: {}
 
   rfdc@1.4.1: {}
@@ -8478,6 +8866,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.27.0: {}
 
@@ -8714,6 +9104,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8766,6 +9160,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-arc-to-cubic-bezier@3.2.0: {}
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.13:
@@ -8783,6 +9179,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -8821,8 +9219,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
 
@@ -8892,6 +9289,16 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.12.2:
@@ -8935,6 +9342,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  util-deprecate@1.0.2: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -8961,6 +9370,12 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite-compatible-readable-stream@3.6.1:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
@@ -9107,6 +9522,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-excel-file@4.1.1:
+    dependencies:
+      fflate: 0.8.3
+
   write-file-atomic@5.0.1:
     dependencies:
       imurmurhash: 0.1.4
@@ -9140,6 +9559,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zeptomatch@2.1.0:
     dependencies:


### PR DESCRIPTION
Agrega exportación de estadísticas en Excel y PDF desde `/estadisticas`.

## Qué incluye
- Botón **Exportar** → modal con selección de formato (Excel / PDF).
- Reporte con: resumen (counts del área), procedencia (internos/externos), distribución por género y por edad — del rango seleccionado (semana/mes/año).
- Generación **100% en el cliente**: PDF con `@react-pdf/renderer` (JSX), Excel con `write-excel-file` (browser-first).

## Diseño
- `buildStatsExport`: modelo neutral, fuente única que consumen ambos generadores.
- Paleta (`reportTheme`) y catálogos de distribución (`distributionConfig`) **compartidos** con las gráficas del dashboard, para que el reporte y la pantalla no se desincronicen.
- Estilo institucional formal, paleta neutra (slate).

## Notas
- `vite.config`: `optimizeDeps.include: ['tslib']` (dep transitiva de react-pdf que el optimizador no descubre solo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added statistics export options in Excel and PDF formats.
  * Added an export dialog with format selection, loading feedback, validation, and success or error notifications.
  * Exported reports include summaries, distribution data, metadata, consistent formatting, and descriptive filenames.
  * Improved dashboard distribution configuration and label consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->